### PR TITLE
fix: added properties in Inventory DTO and removed endpoint 

### DIFF
--- a/product-service/src/main/java/com/mankind/matrix_product_service/controller/InventoryController.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/controller/InventoryController.java
@@ -36,13 +36,6 @@ public class InventoryController {
         return ResponseEntity.ok(inventoryService.getInventoryByProductId(productId));
     }
 
-    @GetMapping("/{productId}/status")
-    @Operation(summary = "Get inventory status", description = "Retrieves simplified inventory status for a product")
-    public ResponseEntity<InventoryStatusDTO> getInventoryStatus(
-            @PathVariable Long productId) {
-        return ResponseEntity.ok(inventoryService.getInventoryStatus(productId));
-    }
-
     @PutMapping("/{productId}")
     @Operation(summary = "Update inventory", description = "Updates inventory stock and/or price information")
     public ResponseEntity<InventoryResponseDTO> updateInventory(

--- a/product-service/src/main/java/com/mankind/matrix_product_service/dto/inventory/InventoryResponseDTO.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/dto/inventory/InventoryResponseDTO.java
@@ -44,4 +44,7 @@ public class InventoryResponseDTO {
 
     @Schema(description = "Maximum quantity allowed per purchase. If not set, no limit will be applied", example = "5")
     private BigDecimal maxQuantityPerPurchase;
+
+    @Schema(description = "Current inventory status", example = "IN_STOCK", allowableValues = {"NO_INVENTORY", "OUT_OF_STOCK", "IN_STOCK"})
+    private String status;
 } 

--- a/product-service/src/main/java/com/mankind/matrix_product_service/dto/inventory/InventoryStatusDTO.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/dto/inventory/InventoryStatusDTO.java
@@ -39,4 +39,7 @@ public class InventoryStatusDTO {
 
     @Schema(description = "Current inventory status", example = "IN_STOCK", allowableValues = {"NO_INVENTORY", "OUT_OF_STOCK", "IN_STOCK"})
     private String status;
+
+    @Schema(description = "Maximum quantity allowed per purchase. If not set, no limit will be applied", example = "5")
+    private BigDecimal maxQuantityPerPurchase;
 } 

--- a/product-service/src/main/java/com/mankind/matrix_product_service/mapper/InventoryMapper.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/mapper/InventoryMapper.java
@@ -35,6 +35,7 @@ public interface InventoryMapper {
     @Mapping(target = "productName", source = "product.name")
     @Mapping(target = "priceDisplay", expression = "java(formatPriceDisplay(inventory.getPrice(), inventory.getCurrency()))")
     @Mapping(target = "maxQuantityPerPurchase", source = "maxQuantityPerPurchase")
+    @Mapping(target = "status", expression = "java(determineStatus(inventory))")
     InventoryResponseDTO toResponseDTO(Inventory inventory);
 
     @Mapping(target = "productId", source = "product.id")

--- a/product-service/src/main/java/com/mankind/matrix_product_service/mapper/ProductMapper.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/mapper/ProductMapper.java
@@ -72,6 +72,7 @@ public interface ProductMapper {
                 .soldQuantity(BigDecimal.ZERO)
                 .totalQuantity(BigDecimal.ZERO)
                 .status("NO_INVENTORY")
+                .maxQuantityPerPurchase(null)
                 .build();
         }
 
@@ -87,6 +88,7 @@ public interface ProductMapper {
             .soldQuantity(inventory.getSoldQuantity())
             .totalQuantity(totalQuantity)
             .status(determineStatus(inventory))
+            .maxQuantityPerPurchase(inventory.getMaxQuantityPerPurchase())
             .build();
     }
 

--- a/product-service/src/main/java/com/mankind/matrix_product_service/mapper/ProductMapper.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/mapper/ProductMapper.java
@@ -72,7 +72,7 @@ public interface ProductMapper {
                 .soldQuantity(BigDecimal.ZERO)
                 .totalQuantity(BigDecimal.ZERO)
                 .status("NO_INVENTORY")
-                .maxQuantityPerPurchase(null)
+                .maxQuantityPerPurchase(null) // Setting maxQuantityPerPurchase to null to indicate no limit or not applicable
                 .build();
         }
 

--- a/product-service/src/main/java/com/mankind/matrix_product_service/service/InventoryService.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/service/InventoryService.java
@@ -63,12 +63,6 @@ public class InventoryService {
                 .orElseThrow(() -> new ResourceNotFoundException("Inventory not found for product: " + productId));
     }
 
-    public InventoryStatusDTO getInventoryStatus(Long productId) {
-        return inventoryRepository.findByProductId(productId)
-                .map(inventoryMapper::toStatusDTO)
-                .orElseThrow(() -> new ResourceNotFoundException("Inventory not found for product: " + productId));
-    }
-
     @Transactional
     public InventoryResponseDTO updateInventory(Long productId, InventoryDTO inventoryDTO) {
         Inventory inventory = inventoryRepository.findByProductId(productId)


### PR DESCRIPTION
## Changes Made

### 1. Enhanced Inventory Status Information
- Added `maxQuantityPerPurchase` field to `InventoryStatusDTO` to track purchase quantity limits
- Updated `ProductMapper` to include `maxQuantityPerPurchase` in inventory status mapping
- Added proper schema documentation for the new field

### 2. API Simplification
- Removed redundant endpoint `GET /api/v1/inventory/{productId}/status`
- Removed associated service method `getInventoryStatus` from `InventoryService`
- Kept `InventoryStatusDTO` as it's used in product responses

### 3. Code Cleanup
- Removed unused endpoint from `InventoryController`
- Maintained consistent inventory status information across all product endpoints
