### PR TITLE
Extract user-api & product-api modules and wire up Feign clients across services

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,9 +269,7 @@ Each service has its own detailed documentation. Click on the service name to vi
    ```bash
    # Build and start all services
    docker-compose up --build
-   
-   # OR run in detached mode (background)
-   docker-compose up -d --build
+
    ```
 
 4. **Manage Docker Services**

--- a/README.md
+++ b/README.md
@@ -325,7 +325,10 @@ For deploying to Render.com, including:
 mankind-backend/
 ├── user-service/         # Handles user authentication & management
 ├── product-service/      # Handles product catalog functionality
-|--...                    # Other services
+├── cart-service/         # Handles shopping cart functionality
+├── wishlist-service/     # Handles wishlist functionality
+├── user-api/            # Shared DTOs and interfaces for user-service
+├── product-api/         # Shared DTOs and interfaces for product-service
 ├── docs/                 # Documentation
 │   └── deploy/          # Deployment guides
 ├── README.md            # Project overview and instructions

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This repository contains the backend microservices for the **Mankind Matrix AI** platform.
 
+## Clone Repository
+
+1. **Clone the Repository**
+   ```bash
+   git clone https://github.com/rebeccayilma/mankind-backend.git
+   cd mankind-backend
+   ```
+
 ## Quick Start
 
 This project can be run in two ways:
@@ -16,285 +24,225 @@ This project can be run in two ways:
    - Best for: Production-like environment and quick setup
    - [Jump to Docker Setup →](#docker-environment)
 
-Choose your preferred method based on your needs. Docker is recommended for most users as it provides a consistent environment and simpler setup.
+You can choose your preferred method based on your needs. Docker is recommended for most users as it provides a consistent environment and a simpler setup.
 
-## Setup Guide
-
-### Clone Repository
-
-1. **Clone the Repository**
-   ```bash
-   git clone https://github.com/rebeccayilma/mankind-backend.git
-   cd mankind-backend
-   ```
-
-2. **Verify the Clone**
-   ```bash
-   # List all services
-   ls
-   
-   # Expected output should include:
-   # user-service/
-   # product-service/
-   # cart-service/
-   # wishlist-service/
-   # docs/
-   # README.md
-   ```
-
-### Database Setup
-
-Before running the services, you need to have a MySQL database running. You have two options:
-
-1. **Local Database**: Run MySQL on your machine
-2. **External Database**: Use a remote MySQL database
-
-For detailed database setup instructions, including:
-- Database creation
-- User setup
-- Required tables and schemas
-- Sample data
-
-[View Database Setup Guide →](docs/database/README.MD)
-
-After setting up the database, configure the connection in each service:
-
-1. Copy the `.env.example` file from the root directory to each service directory:
-   ```bash
-   # From the root directory
-   cp .env.example user-service/.env
-   cp .env.example product-service/.env
-   cp .env.example cart-service/.env
-   cp .env.example wishlist-service/.env
-   ```
-
-2. Update the database connection variables in each service's `.env` file:
-   - `DB_HOST`: Your database host (localhost or remote)
-   - `DB_USERNAME`: Your database username
-   - `DB_PASSWORD`: Your database password
-   - Other variables can remain as they are in the example file
-
-> **Note:** The `.env.example` file in the root directory contains all necessary configuration variables with sample values. You only need to update the database connection details in each service's `.env` file.
+## Local Development
 
 ### Prerequisites
+   <details>
+   <summary><b>Java (JDK 17) </b></summary>
+      
+      #### macOS
+         - Install Homebrew (if not already installed)
+         ```bash
+         /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+         ```
+         - Install Java
+         ```bash
+         brew install openjdk@17
+         ```
+         - Create Java symlink
+         ```bash
+         sudo ln -sfn $(brew --prefix)/opt/openjdk@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk
+         ```
+      
+      #### Windows
+      1. Download OpenJDK 17 from [Adoptium](https://adoptium.net/)
+      2. Run the installer
+      3. Configure environment: Set JAVA_HOME in System Environment Variables
+      
+      #### Linux (Ubuntu/Debian)
+      ```bash
+      sudo apt update
+      sudo apt install openjdk-17-jdk
+      ```
+   </details>
 
-#### Local Development
-- **Java**: JDK 17
-- **MySQL**: 8.0 or newer
-- **Maven**: For building the project
+   <details>
+   <summary><b>MySQL</b></summary>
+   
+   #### macOS
+   ```bash
+   brew install mysql
+   brew services start mysql
+   ```
+   
+   #### Windows
+   1. Download MySQL Installer from [MySQL Website](https://dev.mysql.com/downloads/installer/)
+   2. Choose "Server only" or "Custom" installation type
+   3. Follow the setup wizard
+   
+   #### Linux (Ubuntu/Debian)
+   ```bash
+   sudo apt install mysql-server
+   ```
+   </details>
 
-#### Docker Environment
-- **Docker**: For containerization
-- **Docker Compose**: For multi-container orchestration
+### Run Service
 
-> **Note:** You only need to install the prerequisites for your chosen method. If you're using Docker, you don't need to install Java, MySQL, or Maven locally.
+1. **Configure Environment**
+   - Copy `.env.example` on the folder root
+   - Paste that file in each microservice directory
+   - Rename the file to `.env`
+   - Update the database connection details in each `.env` file
+   - For detailed database configuration, see [Database Setup](#database-setup) section
 
-### Installation
+2. **Build the Services**
+   
+   - Build all services at once, for example:
+   ```bash
+   mvn clean install
+    ```
+   - Or build each service individually
+   ```bash
+   cd user-service
+   ./mvnw clean install
+   ```
+   or 
 
-#### Local Development
+   ```bash
+   cd product-service
+   ./mvnw clean install
+   ```
 
-##### Java (JDK 17)
-<details>
-<summary><b>Installation Instructions</b></summary>
+4. **Run Each Service**
 
-###### macOS
-```bash
-# Install Homebrew (if not already installed)
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+   Enter each service folder and run the commands below:
 
-# Install Java
-brew install openjdk@17
+   For example, run the user-service:
 
-# Create Java symlink
-sudo ln -sfn $(brew --prefix)/opt/openjdk@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk
-```
+   ```bash
+   cd user-service
+   ./mvnw spring-boot:run
+   ```
+   Or run the product service
+   ```bash
+   cd product-service
+   ./mvnw spring-boot:run
+   ```
 
-###### Windows
-1. Download OpenJDK 17 from [Adoptium](https://adoptium.net/)
-2. Run the installer
-3. Configure environment: Set JAVA_HOME in System Environment Variables
+### Service Swagger documentation links:
+- Product Service: [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
+- User Service: [http://localhost:8081/swagger-ui/index.html](http://localhost:8081/swagger-ui/index.html)
+- Cart Service: [http://localhost:8082/swagger-ui/index.html](http://localhost:8082/swagger-ui/index.html)
+- Wishlist Service: [http://localhost:8083/swagger-ui/index.html](http://localhost:8083/swagger-ui/index.html)
 
-###### Linux (Ubuntu/Debian)
-```bash
-sudo apt update
-sudo apt install openjdk-17-jdk
-```
-</details>
+### Services documentation
 
-##### MySQL
-<details>
-<summary><b>Installation Instructions</b></summary>
+Each service has its detailed documentation. Click on the service name to view its specific README:
 
-###### macOS
-```bash
-brew install mysql
-brew services start mysql
-```
-
-###### Windows
-1. Download MySQL Installer from [MySQL Website](https://dev.mysql.com/downloads/installer/)
-2. Choose "Server only" or "Custom" installation type
-3. Follow the setup wizard
-
-###### Linux (Ubuntu/Debian)
-```bash
-sudo apt install mysql-server
-```
-</details>
-
-#### Docker Environment
-
-##### Docker and Docker Compose
-<details>
-<summary><b>Installation Instructions</b></summary>
-
-###### macOS
-1. Install Docker Desktop for Mac
-   - Download from [Docker's official website](https://www.docker.com/products/docker-desktop)
-   - Docker Desktop includes both Docker Engine and Docker Compose
-   - Follow the installation wizard
-
-###### Windows
-1. Install Docker Desktop for Windows
-   - Download from [Docker's official website](https://www.docker.com/products/docker-desktop)
-   - Ensure WSL 2 is installed (Docker Desktop will prompt if not)
-   - Docker Desktop includes both Docker Engine and Docker Compose
-   - Follow the installation wizard
-
-###### Linux (Ubuntu/Debian)
-```bash
-# Update package index
-sudo apt-get update
-
-# Install prerequisites
-sudo apt-get install \
-    ca-certificates \
-    curl \
-    gnupg \
-    lsb-release
-
-# Add Docker's official GPG key
-sudo mkdir -p /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-
-# Set up the repository
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-  $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-# Install Docker Engine and Docker Compose
-sudo apt-get update
-sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-```
-</details>
-
-## Services
-
-Each service has its own detailed documentation. Click on the service name to view its specific README:
-
-### Available Services
+#### Available Services
 - [`user-service/`](user-service/README.md)
 - [`product-service/`](product-service/README.md)
 - [`cart-service/`](cart-service/README.md)
 - [`wishlist-service/`](wishlist-service/README.md)
 
-> **Note:** Each service's README contains specific setup instructions, API documentation, and additional details about that service.
+------------
 
-## Running the Services
-
-### Local Development
-
-#### Prerequisites
-- JDK 17
-- MySQL 8.0+
-- Maven
-
-#### Steps
-
-1. **Configure Environment**
-   - Copy `.env.example` to `.env` in each microservice directory
-   - Update the database connection details in each `.env` file
-   - For detailed database configuration, see [Database Setup](#database-setup) section
-
-2. **Build the Services**
+## Docker Environment
+### Prerequisites
+   <details>
+   <summary><b>Docker and Docker Compose</b></summary>
+   
+   #### macOS
+   1. Install Docker Desktop for Mac
+      - Download from [Docker's official website](https://www.docker.com/products/docker-desktop)
+      - Docker Desktop includes both Docker Engine and Docker Compose
+      - Follow the installation wizard
+   
+   #### Windows
+   1. Install Docker Desktop for Windows
+      - Download from [Docker's official website](https://www.docker.com/products/docker-desktop)
+      - Ensure WSL 2 is installed (Docker Desktop will prompt if not)
+      - Docker Desktop includes both Docker Engine and Docker Compose
+      - Follow the installation wizard
+   
+   #### Linux (Ubuntu/Debian)
    ```bash
-   # Build all services at once
-   mvn clean install
+   # Update package index
+   sudo apt-get update
    
-   # OR build individually
-   cd user-service
-   ./mvnw clean install
+   # Install prerequisites
+   sudo apt-get install \
+       ca-certificates \
+       curl \
+       gnupg \
+       lsb-release
    
-   cd ../product-service
-   ./mvnw clean install
+   # Add Docker's official GPG key
+   sudo mkdir -p /etc/apt/keyrings
+   curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+   
+   # Set up the repository
+   echo \
+     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+     $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+   
+   # Install Docker Engine and Docker Compose
+   sudo apt-get update
+   sudo apt-get install docker-ce docker-ce-cli containerd.io docker-compose-plugin
    ```
-
-3. **Run Each Service**
-   ```bash
-   # Start user-service
-   cd user-service
-   ./mvnw spring-boot:run
+   </details>
    
-   # In a new terminal, start product-service
-   cd product-service
-   ./mvnw spring-boot:run
-   ```
-
-**Service URLs (Local):**
-- Product Service: `http://localhost:8080/swagger-ui/index.html`
-- User Service: `http://localhost:8081/swagger-ui/index.html`
-- Cart Service: `http://localhost:8082/swagger-ui/index.html`
-- Wishlist Service: `http://localhost:8083/swagger-ui/index.html`
-
-### Docker Environment
-
-#### Prerequisites
-- Docker
-- Docker Compose
-
-#### Steps
+### Run Service
 
 1. **Verify Docker Installation**
+   - Check if Docker is running
    ```bash
-   # Check if Docker is running
    docker info
    ```
-
 2. **Configure Environment**
-   - Copy `.env.example` to `.env` in each microservice directory
+   - Copy `.env.example` to the folder root
+   - Paste that file in each microservice directory
+   - Rename the file to `.env`
    - Update the database connection details in each `.env` file
    - For detailed database configuration, see [Database Setup](#database-setup) section
 
 3. **Run All Services**
+   - Build and start all services
    ```bash
-   # Build and start all services
    docker-compose up --build
-
    ```
 
 4. **Manage Docker Services**
+   - Check running containers
    ```bash
-   # Check running containers
    docker-compose ps
+   ```
    
-   # View logs for all services
+   - View logs for all services
+   ```bash
    docker-compose logs
+    ```
    
-   # View logs for a specific service
+   - View logs for a specific service
+   ```bash
    docker-compose logs product-service
+    ```
    
-   # Stop all services
+   - Stop all services
+   ```bash
    docker-compose down
    ```
 
-**Service URLs (Docker):**
-- Product Service: `http://localhost:8080/swagger-ui/index.html`
-- User Service: `http://localhost:8081/swagger-ui/index.html`
-- Cart Service: `http://localhost:8082/swagger-ui/index.html`
-- Wishlist Service: `http://localhost:8083/swagger-ui/index.html`
+### Service Swagger documentation links:
+- Product Service: [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
+- User Service: [http://localhost:8081/swagger-ui/index.html](http://localhost:8081/swagger-ui/index.html)
+- Cart Service: [http://localhost:8082/swagger-ui/index.html](http://localhost:8082/swagger-ui/index.html)
+- Wishlist Service: [http://localhost:8083/swagger-ui/index.html](http://localhost:8083/swagger-ui/index.html)
 
-**Note for Apple Silicon (M1/M2) Users:**
-The Docker setup is configured to use `--platform=linux/amd64` for compatibility. Docker Desktop will handle the emulation automatically.
+
+### Services documentation
+
+Each service has its detailed documentation. Click on the service name to view its specific README:
+
+#### Available Services
+- [`user-service/`](user-service/README.md)
+- [`product-service/`](product-service/README.md)
+- [`cart-service/`](cart-service/README.md)
+- [`wishlist-service/`](wishlist-service/README.md)
+
+------------------
 
 ## Deployment
 
@@ -319,6 +267,8 @@ For deploying to Render.com, including:
 
 > **Note:** Each deployment guide contains platform-specific instructions, cost considerations, and best practices. Choose the platform that best fits your requirements and budget.
 
+
+------------------
 ## Project Structure
 
 ```
@@ -336,4 +286,4 @@ mankind-backend/
 
 ## Contributing
 
-Create a branch for the feature you are working on and when done, create a Pull request and share it for review before merging.
+Create a branch for the feature you are working on. When you are done, create a Pull request and share it for review before merging.

--- a/cart-service/Dockerfile
+++ b/cart-service/Dockerfile
@@ -5,7 +5,10 @@ WORKDIR /build
 # Copy the entire project
 COPY . .
 
-# Build the application with explicit executable JAR creation
+# First, build and install the API modules to local repository
+RUN mvn clean install -pl user-api,product-api -am -DskipTests
+
+# Then build the cart service
 RUN cd cart-service && \
     mvn clean package spring-boot:repackage -DskipTests && \
     ls -la target/

--- a/cart-service/pom.xml
+++ b/cart-service/pom.xml
@@ -8,9 +8,7 @@
         <version>1.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <groupId>com.mankind</groupId>
-    <artifactId>Matrix_Cart_Service</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <artifactId>cart-service</artifactId>
     <name>Mankind Matrix Cart Service</name>
     <description>Mankind Matrix Cart Service</description>
     <url/>
@@ -27,7 +25,6 @@
         <url/>
     </scm>
     <properties>
-        <java.version>17</java.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
     </properties>
     <dependencies>
@@ -47,7 +44,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
@@ -63,6 +63,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+        <!-- API Modules-->
+        <dependency>
+            <groupId>com.mankind</groupId>
+            <artifactId>product-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mankind</groupId>
+            <artifactId>user-api</artifactId>
         </dependency>
 
         <dependency>

--- a/cart-service/src/main/java/com/mankind/matrix_cart_service/dto/CartItemRequestDto.java
+++ b/cart-service/src/main/java/com/mankind/matrix_cart_service/dto/CartItemRequestDto.java
@@ -1,5 +1,6 @@
 package com.mankind.matrix_cart_service.dto;
 
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -23,5 +24,6 @@ public class CartItemRequestDto {
     private int quantity;
 
     @NotNull(message = "Price cannot be null")
+    @DecimalMin(value = "0.01", message = "Price must be greater than zero")
     private double price;
 }

--- a/docs/architecture/api-feign-pattern-guide.md
+++ b/docs/architecture/api-feign-pattern-guide.md
@@ -1,0 +1,244 @@
+# Multi-Module API & Feign Pattern Guide
+
+This document shows how we’ve structured `user-api` & `product-api` modules, wired them into services with Feign clients, and how you can apply the same steps to any **new service** you add.
+
+---
+
+## 1. Why this pattern?
+
+- **Separation of Concerns**
+    - `*-api` modules hold *only* DTOs, enums, validation annotations, and (optionally) OpenAPI specs.
+    - Service modules contain business logic, persistence, Feign clients, and controllers.
+
+- **Loose Coupling**
+    - Consumers depend on a stable *contract* JAR, not internal entities.
+    - Breaking changes to persistence layer don’t ripple to clients.
+
+- **Secure Service to Service**
+    - Feign + header-propagating interceptor ensures JWTs flow between services without opening endpoints to anonymous traffic.
+
+- **Ease of Onboarding**
+    - New services simply add the matching `*-api` and Feign client; no manual DTO copying.
+
+---
+
+## 2. Project Layout
+
+```
+mankind-backend/
+├── pom.xml
+├── user-api/
+├── product-api/
+├── user-service/
+├── product-service/
+├── cart-service/
+├── wishlist-service/
+└── api-gateway/
+```
+
+---
+
+## 3. Extract DTOs into `*-api` Modules
+
+1. Create module structure:
+   ```bash
+   mkdir -p new-api/src/main/java/com/mankind/api/new
+   mkdir -p new-api/src/main/resources
+   ```
+2. Minimal `new-api/pom.xml`:
+   ```xml
+   <project>
+     <parent>
+       <groupId>com.mankind</groupId>
+       <artifactId>mankind-backend</artifactId>
+       <version>${project.version}</version>
+     </parent>
+     <artifactId>new-api</artifactId>
+     <packaging>jar</packaging>
+     <dependencies>
+       <dependency>
+         <groupId>com.fasterxml.jackson.core</groupId>
+         <artifactId>jackson-databind</artifactId>
+       </dependency>
+       <dependency>
+         <groupId>jakarta.validation</groupId>
+         <artifactId>jakarta.validation-api</artifactId>
+       </dependency>
+       <dependency>
+         <groupId>org.projectlombok</groupId>
+         <artifactId>lombok</artifactId>
+         <scope>provided</scope>
+       </dependency>
+     </dependencies>
+   </project>
+   ```
+3. Move DTOs & enums into `new-api`; update packages to `com.mankind.api.new`.
+4. Build to verify:
+   ```bash
+   mvn clean install -pl new-api
+   ```
+
+---
+
+## 4. Wire Service Module to the `*-api`
+
+1. Add dependency in `new-service/pom.xml`:
+   ```xml
+   <dependency>
+     <groupId>com.mankind</groupId>
+     <artifactId>new-api</artifactId>
+   </dependency>
+   ```
+2. Remove old DTO folder from `new-service`.
+3. Import shared types:
+   ```java
+   import com.mankind.api.new.YourDTO;
+   ```
+4. Rebuild:
+   ```bash
+   mvn clean install -pl new-service
+   ```
+
+---
+
+## 5. Add Feign Client for Service to Service Calls
+
+### A. Configure External Service URL
+In `new-service/src/main/resources/application.yml`:
+```yaml
+peer-service:
+  url: http://localhost:8081
+```
+
+### B. Add Feign dependencies
+In `new-service/pom.xml`:
+```xml
+<dependencyManagement>
+  <dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-dependencies</artifactId>
+    <version>${springframework.cloud.version}</version>
+    <type>pom</type>
+    <scope>import</scope>
+  </dependency>
+</dependencyManagement>
+<dependencies>
+  <dependency>
+    <groupId>org.springframework.cloud</groupId>
+    <artifactId>spring-cloud-starter-openfeign</artifactId>
+  </dependency>
+  <dependency>
+    <groupId>com.mankind</groupId>
+    <artifactId>peer-api</artifactId>
+  </dependency>
+</dependencies>
+```
+
+### C. FeignConfig for Header Propagation
+```java
+package com.mankind.newservice.config;
+
+import feign.RequestInterceptor;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Configuration
+public class FeignConfig {
+    @Bean
+    public RequestInterceptor propagateAuthToken() {
+        return template -> {
+            ServletRequestAttributes attrs =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attrs != null) {
+                HttpServletRequest req = attrs.getRequest();
+                String auth = req.getHeader(HttpHeaders.AUTHORIZATION);
+                if (StringUtils.hasText(auth)) {
+                    template.header(HttpHeaders.AUTHORIZATION, auth);
+                }
+            }
+        };
+    }
+}
+```
+
+### D. Feign Client Interface
+```java
+package com.mankind.newservice.client;
+
+import com.mankind.api.peer.PeerDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(
+  name = "peer-service",
+  url = "${peer-service.url}",
+  configuration = com.mankind.newservice.config.FeignConfig.class
+)
+public interface PeerClient {
+    @GetMapping("/api/v1/peers/{id}")
+    PeerDTO getPeerById(@PathVariable Long id);
+    @GetMapping("/api/v1/peers")
+    List<PeerDTO> getAllPeers();
+}
+```
+
+### E. Enable Feign in Main App
+```java
+@SpringBootApplication
+@EnableFeignClients(basePackages = "com.mankind.newservice")
+public class NewServiceApplication { … }
+```
+
+### F. Use in Controller
+```java
+@RestController
+public class TestController {
+  private final PeerClient peerClient;
+  public TestController(PeerClient peerClient) {
+    this.peerClient = peerClient;
+  }
+  @GetMapping("/api/test/peer/{id}")
+  public PeerDTO getPeer(@PathVariable Long id) {
+    return peerClient.getPeerById(id);
+  }
+}
+```
+
+---
+
+## 6. Security Config in Auth Service
+```java
+@Bean
+public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  http
+    .csrf().disable()
+    .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+    .authorizeHttpRequests(auth -> auth
+      .requestMatchers("/api/v1/auth/**").permitAll()
+      .anyRequest().authenticated()
+    )
+    .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+  return http.build();
+}
+```
+
+---
+
+## 7. Testing & Next Steps
+
+1. Start peer-service (auth) on port 8081.
+2. Login to get JWT:
+   ```bash
+   curl -X POST http://localhost:8081/api/v1/auth/login      -d '{"username":"user","password":"pass"}'
+   ```  
+3. Start new-service on port 8082 and call test endpoint:
+   ```bash
+   curl http://localhost:8082/api/test/peer/1      -H "Authorization: Bearer <token>"
+   ```
+4. Future: replace static URLs with Eureka; add API Gateway; circuit breakers; refresh-token flow.

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <java.version>17</java.version>
     <spring.boot.version>3.2.4</spring.boot.version>
     <springframework.cloud.version>2023.0.5</springframework.cloud.version>
+    <lombok.version>1.18.30</lombok.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -47,6 +48,12 @@
         <artifactId>product-api</artifactId>
         <version>${project.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <version>${lombok.version}</version>
+        <scope>provided</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>
@@ -59,9 +66,17 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.11.0</version>
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>
+            <annotationProcessorPaths>
+              <path>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+              </path>
+            </annotationProcessorPaths>
           </configuration>
         </plugin>
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1,57 +1,70 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                              https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.mankind</groupId>
+  <artifactId>mankind-backend</artifactId>
+  <version>1.0.0</version>
+  <packaging>pom</packaging>
+  <name>Mankind Backend Monorepo</name>
+  <description>Multi-module Spring Boot backend for Mankind Matrix</description>
+  <modules>
+    <module>user-service</module>
+    <module>product-service</module>
+    <module>cart-service</module>
+    <module>wishlist-service</module>
+    <!--  api modules -->
+    <module>user-api</module>
+    <module>product-api</module>
 
-    <groupId>com.mankind</groupId>
-    <artifactId>mankind-backend</artifactId>
-    <version>1.0.0</version>
-    <packaging>pom</packaging>
-
-    <name>Mankind Backend Monorepo</name>
-    <description>Multi-module Spring Boot backend for Mankind Matrix</description>
-
-    <modules>
-        <module>user-service</module>
-        <module>product-service</module>
-        <module>cart-service</module>
-        <module>wishlist-service</module>
-     </modules>
-
-    <properties>
-        <java.version>17</java.version>
-        <spring.boot.version>3.2.4</spring.boot.version>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring.boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-maven-plugin</artifactId>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <source>${java.version}</source>
-                        <target>${java.version}</target>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
+  </modules>
+  <properties>
+    <java.version>17</java.version>
+    <spring.boot.version>3.2.4</spring.boot.version>
+    <springframework.cloud.version>2023.0.5</springframework.cloud.version>
+  </properties>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.cloud</groupId>
+        <artifactId>spring-cloud-dependencies</artifactId>
+        <version>${springframework.cloud.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.mankind</groupId>
+        <artifactId>user-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.mankind</groupId>
+        <artifactId>product-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/product-api/pom.xml
+++ b/product-api/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.mankind</groupId>
+        <artifactId>mankind-backend</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>product-api</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Product API</name>
+    <description>DTOs and interfaces for product-service</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/product-api/src/main/java/com/mankind/api/product/dto/category/CategoryDTO.java
+++ b/product-api/src/main/java/com/mankind/api/product/dto/category/CategoryDTO.java
@@ -1,4 +1,4 @@
-package com.mankind.matrix_product_service.dto.category;
+package com.mankind.api.product.dto.category;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/product-api/src/main/java/com/mankind/api/product/dto/category/CategoryResponseDTO.java
+++ b/product-api/src/main/java/com/mankind/api/product/dto/category/CategoryResponseDTO.java
@@ -1,4 +1,4 @@
-package com.mankind.matrix_product_service.dto.category;
+package com.mankind.api.product.dto.category;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;

--- a/product-api/src/main/java/com/mankind/api/product/dto/inventory/InventoryDTO.java
+++ b/product-api/src/main/java/com/mankind/api/product/dto/inventory/InventoryDTO.java
@@ -1,4 +1,4 @@
-package com.mankind.matrix_product_service.dto.inventory;
+package com.mankind.api.product.dto.inventory;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMin;

--- a/product-api/src/main/java/com/mankind/api/product/dto/inventory/InventoryLogDTO.java
+++ b/product-api/src/main/java/com/mankind/api/product/dto/inventory/InventoryLogDTO.java
@@ -1,4 +1,4 @@
-package com.mankind.matrix_product_service.dto.inventory;
+package com.mankind.api.product.dto.inventory;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/product-api/src/main/java/com/mankind/api/product/dto/inventory/InventoryResponseDTO.java
+++ b/product-api/src/main/java/com/mankind/api/product/dto/inventory/InventoryResponseDTO.java
@@ -1,4 +1,4 @@
-package com.mankind.matrix_product_service.dto.inventory;
+package com.mankind.api.product.dto.inventory;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;

--- a/product-api/src/main/java/com/mankind/api/product/dto/inventory/InventoryStatusDTO.java
+++ b/product-api/src/main/java/com/mankind/api/product/dto/inventory/InventoryStatusDTO.java
@@ -1,4 +1,4 @@
-package com.mankind.matrix_product_service.dto.inventory;
+package com.mankind.api.product.dto.inventory;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;

--- a/product-api/src/main/java/com/mankind/api/product/dto/product/ProductDTO.java
+++ b/product-api/src/main/java/com/mankind/api/product/dto/product/ProductDTO.java
@@ -1,4 +1,4 @@
-package com.mankind.matrix_product_service.dto.product;
+package com.mankind.api.product.dto.product;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;

--- a/product-api/src/main/java/com/mankind/api/product/dto/product/ProductResponseDTO.java
+++ b/product-api/src/main/java/com/mankind/api/product/dto/product/ProductResponseDTO.java
@@ -1,11 +1,10 @@
-package com.mankind.matrix_product_service.dto.product;
+package com.mankind.api.product.dto.product;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
-import com.mankind.matrix_product_service.dto.inventory.InventoryStatusDTO;
-import com.mankind.matrix_product_service.dto.category.CategoryResponseDTO;
+import com.mankind.api.product.dto.inventory.InventoryStatusDTO;
+import com.mankind.api.product.dto.category.CategoryResponseDTO;
 
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;

--- a/product-api/src/main/java/com/mankind/api/product/dto/recentlyviewed/RecentlyViewedProductResponseDTO.java
+++ b/product-api/src/main/java/com/mankind/api/product/dto/recentlyviewed/RecentlyViewedProductResponseDTO.java
@@ -1,6 +1,6 @@
-package com.mankind.matrix_product_service.dto.recentlyviewed;
+package com.mankind.api.product.dto.recentlyviewed;
 
-import com.mankind.matrix_product_service.dto.product.ProductResponseDTO;
+import com.mankind.api.product.dto.product.ProductResponseDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/product-service/Dockerfile
+++ b/product-service/Dockerfile
@@ -5,7 +5,10 @@ WORKDIR /build
 # Copy the entire project
 COPY . .
 
-# Build the application with explicit executable JAR creation
+# First, build and install the API modules to local repository
+RUN mvn clean install -pl user-api,product-api -am -DskipTests
+
+# Then build the product service
 RUN cd product-service && \
     mvn clean package spring-boot:repackage -DskipTests && \
     ls -la target/

--- a/product-service/api/requests.http
+++ b/product-service/api/requests.http
@@ -2,6 +2,8 @@
 @baseUrl = http://localhost:8080
 @id = 1
 @categoryId = 1
+@token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzYW1wbGVVc2VyIiwiaWF0IjoxNzUwMDQzMjE3LCJleHAiOjE3NTAxMjk2MTd9.9boM4n6QUf7ZimVLRQjjqTEC3xQ3V6YyBR4EtqXHB6Y
+
 
 ### Product Management ###
 
@@ -12,6 +14,11 @@ Accept: application/json
 ### Get product by ID
 GET {{baseUrl}}/api/v1/products/{{id}}
 Accept: application/json
+
+### Get user by ID
+GET {{baseUrl}}/api/test/users
+Accept: application/json
+Authorization: Bearer {{token}}
 
 ### Get products by category (paginated)
 GET {{baseUrl}}/api/v1/products/category/{{categoryId}}?page=0&size=10

--- a/product-service/pom.xml
+++ b/product-service/pom.xml
@@ -8,9 +8,7 @@
         <version>1.0.0</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <groupId>com.mankind</groupId>
-    <artifactId>Matrix_Product_Service</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <artifactId>product-service</artifactId>
     <name>Mankind Matrix Product Service</name>
     <description>Mankind Matrix Product Service</description>
     <url/>
@@ -27,7 +25,6 @@
         <url/>
     </scm>
     <properties>
-        <java.version>17</java.version>
         <mapstruct.version>1.5.5.Final</mapstruct.version>
     </properties>
     <dependencies>
@@ -43,7 +40,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
 
+        <dependency>
+            <groupId>com.mankind</groupId>
+            <artifactId>user-api</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
@@ -52,13 +57,18 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.30</version>
-            <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!--api Modules-->
+        <dependency>
+            <groupId>com.mankind</groupId>
+            <artifactId>product-api</artifactId>
         </dependency>
 
         <dependency>
@@ -91,6 +101,18 @@
             <artifactId>spring-boot-starter-actuator</artifactId>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${springframework.cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/product-service/src/main/java/com/mankind/matrix_product_service/MankindMatrixProductServiceApplication.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/MankindMatrixProductServiceApplication.java
@@ -2,10 +2,12 @@ package com.mankind.matrix_product_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableFeignClients
 public class MankindMatrixProductServiceApplication {
 
     public static void main(String[] args) {

--- a/product-service/src/main/java/com/mankind/matrix_product_service/client/UserClient.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/client/UserClient.java
@@ -1,0 +1,17 @@
+package com.mankind.matrix_product_service.client;
+
+import com.mankind.api.user.dto.UserDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@FeignClient(name = "user-service", url = "${user-service.url}")
+public interface UserClient {
+    @GetMapping("/api/v1/users/{id}")
+    UserDTO getUserById(@PathVariable("id") Long id);
+
+    @GetMapping("/api/v1/users")
+    List<UserDTO> getAllUsers();
+}

--- a/product-service/src/main/java/com/mankind/matrix_product_service/config/WebConfig.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/config/WebConfig.java
@@ -1,7 +1,12 @@
 package com.mankind.matrix_product_service.config;
 
+import feign.RequestInterceptor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -16,6 +21,19 @@ public class WebConfig {
                 registry.addMapping("/**")
                         .allowedOrigins("http://localhost:3000")
                         .allowedMethods("*");
+            }
+        };
+    }
+    @Bean
+    public RequestInterceptor propagateBearerToken() {
+        return template -> {
+            ServletRequestAttributes attrs =
+                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attrs != null) {
+                String auth = attrs.getRequest().getHeader(HttpHeaders.AUTHORIZATION);
+                if (StringUtils.hasText(auth)) {
+                    template.header(HttpHeaders.AUTHORIZATION, auth);
+                }
             }
         };
     }

--- a/product-service/src/main/java/com/mankind/matrix_product_service/controller/CategoryController.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/controller/CategoryController.java
@@ -1,7 +1,8 @@
 package com.mankind.matrix_product_service.controller;
 
-import com.mankind.matrix_product_service.dto.category.CategoryDTO;
-import com.mankind.matrix_product_service.dto.category.CategoryResponseDTO;
+
+import com.mankind.api.product.dto.category.CategoryDTO;
+import com.mankind.api.product.dto.category.CategoryResponseDTO;
 import com.mankind.matrix_product_service.service.CategoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/product-service/src/main/java/com/mankind/matrix_product_service/controller/InventoryController.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/controller/InventoryController.java
@@ -1,9 +1,8 @@
 package com.mankind.matrix_product_service.controller;
 
-import com.mankind.matrix_product_service.dto.inventory.InventoryDTO;
-import com.mankind.matrix_product_service.dto.inventory.InventoryLogDTO;
-import com.mankind.matrix_product_service.dto.inventory.InventoryResponseDTO;
-import com.mankind.matrix_product_service.dto.inventory.InventoryStatusDTO;
+import com.mankind.api.product.dto.inventory.InventoryDTO;
+import com.mankind.api.product.dto.inventory.InventoryLogDTO;
+import com.mankind.api.product.dto.inventory.InventoryResponseDTO;
 import com.mankind.matrix_product_service.service.InventoryService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/product-service/src/main/java/com/mankind/matrix_product_service/controller/ProductController.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/controller/ProductController.java
@@ -1,7 +1,8 @@
 package com.mankind.matrix_product_service.controller;
 
-import com.mankind.matrix_product_service.dto.product.ProductDTO;
-import com.mankind.matrix_product_service.dto.product.ProductResponseDTO;
+
+import com.mankind.api.product.dto.product.ProductDTO;
+import com.mankind.api.product.dto.product.ProductResponseDTO;
 import com.mankind.matrix_product_service.service.ProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;

--- a/product-service/src/main/java/com/mankind/matrix_product_service/controller/RecentlyViewedProductController.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/controller/RecentlyViewedProductController.java
@@ -1,6 +1,6 @@
 package com.mankind.matrix_product_service.controller;
 
-import com.mankind.matrix_product_service.dto.recentlyviewed.RecentlyViewedProductResponseDTO;
+import com.mankind.api.product.dto.recentlyviewed.RecentlyViewedProductResponseDTO;
 import com.mankind.matrix_product_service.service.RecentlyViewedProductService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -12,7 +12,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/product-service/src/main/java/com/mankind/matrix_product_service/mapper/CategoryMapper.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/mapper/CategoryMapper.java
@@ -1,7 +1,8 @@
 package com.mankind.matrix_product_service.mapper;
 
-import com.mankind.matrix_product_service.dto.category.CategoryDTO;
-import com.mankind.matrix_product_service.dto.category.CategoryResponseDTO;
+
+import com.mankind.api.product.dto.category.CategoryDTO;
+import com.mankind.api.product.dto.category.CategoryResponseDTO;
 import com.mankind.matrix_product_service.model.Category;
 import org.mapstruct.*;
 

--- a/product-service/src/main/java/com/mankind/matrix_product_service/mapper/InventoryLogMapper.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/mapper/InventoryLogMapper.java
@@ -1,6 +1,6 @@
 package com.mankind.matrix_product_service.mapper;
 
-import com.mankind.matrix_product_service.dto.inventory.InventoryLogDTO;
+import com.mankind.api.product.dto.inventory.InventoryLogDTO;
 import com.mankind.matrix_product_service.model.InventoryLog;
 import org.mapstruct.*;
 

--- a/product-service/src/main/java/com/mankind/matrix_product_service/mapper/InventoryMapper.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/mapper/InventoryMapper.java
@@ -1,8 +1,8 @@
 package com.mankind.matrix_product_service.mapper;
 
-import com.mankind.matrix_product_service.dto.inventory.InventoryDTO;
-import com.mankind.matrix_product_service.dto.inventory.InventoryResponseDTO;
-import com.mankind.matrix_product_service.dto.inventory.InventoryStatusDTO;
+import com.mankind.api.product.dto.inventory.InventoryDTO;
+import com.mankind.api.product.dto.inventory.InventoryResponseDTO;
+import com.mankind.api.product.dto.inventory.InventoryStatusDTO;
 import com.mankind.matrix_product_service.model.Inventory;
 import org.mapstruct.*;
 

--- a/product-service/src/main/java/com/mankind/matrix_product_service/mapper/ProductMapper.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/mapper/ProductMapper.java
@@ -1,9 +1,8 @@
 package com.mankind.matrix_product_service.mapper;
 
-import com.mankind.matrix_product_service.dto.product.ProductDTO;
-import com.mankind.matrix_product_service.dto.product.ProductResponseDTO;
-import com.mankind.matrix_product_service.dto.inventory.InventoryStatusDTO;
-import com.mankind.matrix_product_service.dto.category.CategoryResponseDTO;
+import com.mankind.api.product.dto.inventory.InventoryStatusDTO;
+import com.mankind.api.product.dto.product.ProductDTO;
+import com.mankind.api.product.dto.product.ProductResponseDTO;
 import com.mankind.matrix_product_service.model.Inventory;
 import com.mankind.matrix_product_service.model.Product;
 import org.mapstruct.*;

--- a/product-service/src/main/java/com/mankind/matrix_product_service/mapper/RecentlyViewedProductMapper.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/mapper/RecentlyViewedProductMapper.java
@@ -1,6 +1,6 @@
 package com.mankind.matrix_product_service.mapper;
 
-import com.mankind.matrix_product_service.dto.recentlyviewed.RecentlyViewedProductResponseDTO;
+import com.mankind.api.product.dto.recentlyviewed.RecentlyViewedProductResponseDTO;
 import com.mankind.matrix_product_service.model.RecentlyViewedProduct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;

--- a/product-service/src/main/java/com/mankind/matrix_product_service/service/CategoryService.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/service/CategoryService.java
@@ -1,7 +1,8 @@
 package com.mankind.matrix_product_service.service;
 
-import com.mankind.matrix_product_service.dto.category.CategoryDTO;
-import com.mankind.matrix_product_service.dto.category.CategoryResponseDTO;
+
+import com.mankind.api.product.dto.category.CategoryDTO;
+import com.mankind.api.product.dto.category.CategoryResponseDTO;
 import com.mankind.matrix_product_service.exception.DuplicateResourceException;
 import com.mankind.matrix_product_service.exception.ResourceNotFoundException;
 import com.mankind.matrix_product_service.model.Category;

--- a/product-service/src/main/java/com/mankind/matrix_product_service/service/InventoryService.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/service/InventoryService.java
@@ -1,9 +1,9 @@
 package com.mankind.matrix_product_service.service;
 
-import com.mankind.matrix_product_service.dto.inventory.InventoryDTO;
-import com.mankind.matrix_product_service.dto.inventory.InventoryLogDTO;
-import com.mankind.matrix_product_service.dto.inventory.InventoryResponseDTO;
-import com.mankind.matrix_product_service.dto.inventory.InventoryStatusDTO;
+
+import com.mankind.api.product.dto.inventory.InventoryDTO;
+import com.mankind.api.product.dto.inventory.InventoryLogDTO;
+import com.mankind.api.product.dto.inventory.InventoryResponseDTO;
 import com.mankind.matrix_product_service.exception.ResourceNotFoundException;
 import com.mankind.matrix_product_service.mapper.InventoryLogMapper;
 import com.mankind.matrix_product_service.mapper.InventoryMapper;

--- a/product-service/src/main/java/com/mankind/matrix_product_service/service/ProductService.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/service/ProductService.java
@@ -1,7 +1,7 @@
 package com.mankind.matrix_product_service.service;
 
-import com.mankind.matrix_product_service.dto.product.ProductDTO;
-import com.mankind.matrix_product_service.dto.product.ProductResponseDTO;
+import com.mankind.api.product.dto.product.ProductDTO;
+import com.mankind.api.product.dto.product.ProductResponseDTO;
 import com.mankind.matrix_product_service.exception.ResourceNotFoundException;
 import com.mankind.matrix_product_service.mapper.ProductMapper;
 import com.mankind.matrix_product_service.model.Product;
@@ -12,7 +12,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/product-service/src/main/java/com/mankind/matrix_product_service/service/RecentlyViewedProductService.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/service/RecentlyViewedProductService.java
@@ -1,6 +1,6 @@
 package com.mankind.matrix_product_service.service;
 
-import com.mankind.matrix_product_service.dto.recentlyviewed.RecentlyViewedProductResponseDTO;
+import com.mankind.api.product.dto.recentlyviewed.RecentlyViewedProductResponseDTO;
 import com.mankind.matrix_product_service.exception.ResourceNotFoundException;
 import com.mankind.matrix_product_service.exception.InvalidOperationException;
 import com.mankind.matrix_product_service.mapper.RecentlyViewedProductMapper;

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -29,6 +29,21 @@ spring:
           auto_commit: true
   profiles:
     active: dev
+
+# Application specific properties
+app:
+  services:
+    user-service:
+      url: ${USER_SERVICE_URL:http://localhost:8081}
+
+# Feign client configuration
+feign:
+  client:
+    config:
+      default:
+        connectTimeout: 5000
+        readTimeout: 5000
+        loggerLevel: full
 management:
   endpoints:
     web:
@@ -45,8 +60,10 @@ management:
     readinessState:
       enabled: true
 
-app:
-  recently-viewed:
-    max-items: 10
+
 user-service:
   url: http://localhost:8081
+
+#app:
+#  recently-viewed:
+#    max-items: 10

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -48,3 +48,5 @@ management:
 app:
   recently-viewed:
     max-items: 10
+user-service:
+  url: http://localhost:8081

--- a/user-api/pom.xml
+++ b/user-api/pom.xml
@@ -1,0 +1,31 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>com.mankind</groupId>
+        <artifactId>mankind-backend</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>user-api</artifactId>
+    <name>User API</name>
+    <packaging>jar</packaging>
+
+    <description>DTOs and interfaces for user-service</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/user-api/src/main/java/com/mankind/api/user/dto/AddressDTO.java
+++ b/user-api/src/main/java/com/mankind/api/user/dto/AddressDTO.java
@@ -1,6 +1,6 @@
-package com.mankind.mankindmatrixuserservice.dto;
+package com.mankind.api.user.dto;
 
-import com.mankind.mankindmatrixuserservice.model.Address;
+import com.mankind.api.user.enums.AddressType;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public class AddressDTO {
     private Long id;
     private Long userId;
-    private Address.AddressType addressType;
+    private AddressType addressType;
     private Boolean isDefault;
     private String streetAddress;
     private String city;

--- a/user-api/src/main/java/com/mankind/api/user/dto/AuthRequest.java
+++ b/user-api/src/main/java/com/mankind/api/user/dto/AuthRequest.java
@@ -1,4 +1,4 @@
-package com.mankind.mankindmatrixuserservice.dto;
+package com.mankind.api.user.dto;
 
 import lombok.Data;
 

--- a/user-api/src/main/java/com/mankind/api/user/dto/AuthResponse.java
+++ b/user-api/src/main/java/com/mankind/api/user/dto/AuthResponse.java
@@ -2,9 +2,11 @@ package com.mankind.api.user.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class AuthResponse {
     private String token;
 }

--- a/user-api/src/main/java/com/mankind/api/user/dto/AuthResponse.java
+++ b/user-api/src/main/java/com/mankind/api/user/dto/AuthResponse.java
@@ -1,4 +1,4 @@
-package com.mankind.mankindmatrixuserservice.dto;
+package com.mankind.api.user.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/user-api/src/main/java/com/mankind/api/user/dto/CreateAddressDTO.java
+++ b/user-api/src/main/java/com/mankind/api/user/dto/CreateAddressDTO.java
@@ -1,11 +1,11 @@
-package com.mankind.mankindmatrixuserservice.dto;
+package com.mankind.api.user.dto;
 
-import com.mankind.mankindmatrixuserservice.model.Address;
+import com.mankind.api.user.enums.AddressType;
 import lombok.Data;
 
 @Data
 public class CreateAddressDTO {
-    private Address.AddressType addressType;
+    private AddressType addressType;
     private Boolean isDefault = false;
     private String streetAddress;
     private String city;

--- a/user-api/src/main/java/com/mankind/api/user/dto/UpdateAddressDTO.java
+++ b/user-api/src/main/java/com/mankind/api/user/dto/UpdateAddressDTO.java
@@ -1,11 +1,11 @@
-package com.mankind.mankindmatrixuserservice.dto;
+package com.mankind.api.user.dto;
 
-import com.mankind.mankindmatrixuserservice.model.Address;
+import com.mankind.api.user.enums.AddressType;
 import lombok.Data;
 
 @Data
 public class UpdateAddressDTO {
-    private Address.AddressType addressType;
+    private AddressType addressType;
     private Boolean isDefault;
     private String streetAddress;
     private String city;

--- a/user-api/src/main/java/com/mankind/api/user/dto/UpdateUserDTO.java
+++ b/user-api/src/main/java/com/mankind/api/user/dto/UpdateUserDTO.java
@@ -1,4 +1,4 @@
-package com.mankind.mankindmatrixuserservice.dto;
+package com.mankind.api.user.dto;
 
 import lombok.Data;
 

--- a/user-api/src/main/java/com/mankind/api/user/dto/UserDTO.java
+++ b/user-api/src/main/java/com/mankind/api/user/dto/UserDTO.java
@@ -1,7 +1,7 @@
-package com.mankind.mankindmatrixuserservice.dto;
+package com.mankind.api.user.dto;
 
 
-import com.mankind.mankindmatrixuserservice.model.Role;
+import com.mankind.api.user.enums.Role;
 import lombok.Data;
 
 import java.time.LocalDateTime;

--- a/user-api/src/main/java/com/mankind/api/user/enums/AddressType.java
+++ b/user-api/src/main/java/com/mankind/api/user/enums/AddressType.java
@@ -1,0 +1,5 @@
+package com.mankind.api.user.enums;
+
+public enum AddressType {
+    billing, shipping
+}

--- a/user-api/src/main/java/com/mankind/api/user/enums/Role.java
+++ b/user-api/src/main/java/com/mankind/api/user/enums/Role.java
@@ -1,4 +1,4 @@
-package com.mankind.mankindmatrixuserservice.model;
+package com.mankind.api.user.enums;
 
 public enum Role {
     ADMIN,

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -5,7 +5,10 @@ WORKDIR /build
 # Copy the entire project
 COPY . .
 
-# Build the application with explicit executable JAR creation
+# First, build and install the API modules to local repository
+RUN mvn clean install -pl user-api,product-api -am -DskipTests
+
+# Then build the user service
 RUN cd user-service && \
     mvn clean package spring-boot:repackage -DskipTests && \
     ls -la target/

--- a/user-service/api/requests.http
+++ b/user-service/api/requests.http
@@ -1,5 +1,5 @@
 ##replace Token value after each login
-@token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzYW1wbGVVc2VyIiwiaWF0IjoxNzQ3MDU4NDY0LCJleHAiOjE3NDcxNDQ4NjR9.5w8X3eDOWTVc_N9kDMCFASjhqwJTrw0C8aCMh0PwG2c
+@token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzYW1wbGVVc2VyIiwiaWF0IjoxNzUwMDQzMjE3LCJleHAiOjE3NTAxMjk2MTd9.9boM4n6QUf7ZimVLRQjjqTEC3xQ3V6YyBR4EtqXHB6Y
 @userId = 1
 ### Create User
 
@@ -32,7 +32,7 @@ Content-Type: application/json
 ###
 
 ### Get User by ID
-GET http://localhost:8081/api/v1/users/1
+GET http://localhost:8081/api/v1/users/2
 Accept: application/json
 Authorization: Bearer {{token}}
 

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -40,6 +40,17 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-openfeign</artifactId>
+        </dependency>
+
+        <!-- api-->
+        <dependency>
+            <groupId>com.mankind</groupId>
+            <artifactId>user-api</artifactId>
+        </dependency>
+
 
         <dependency>
             <groupId>com.mysql</groupId>

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/controller/AuthController.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/controller/AuthController.java
@@ -1,8 +1,8 @@
 package com.mankind.mankindmatrixuserservice.controller;
 
-import com.mankind.mankindmatrixuserservice.dto.AuthRequest;
-import com.mankind.mankindmatrixuserservice.dto.AuthResponse;
-import com.mankind.mankindmatrixuserservice.dto.UserDTO;
+import com.mankind.api.user.dto.AuthRequest;
+import com.mankind.api.user.dto.AuthResponse;
+import com.mankind.api.user.dto.UserDTO;
 import com.mankind.mankindmatrixuserservice.service.JwtService;
 import com.mankind.mankindmatrixuserservice.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/controller/UserController.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/controller/UserController.java
@@ -1,10 +1,10 @@
 package com.mankind.mankindmatrixuserservice.controller;
 
-import com.mankind.mankindmatrixuserservice.dto.AddressDTO;
-import com.mankind.mankindmatrixuserservice.dto.CreateAddressDTO;
-import com.mankind.mankindmatrixuserservice.dto.UpdateAddressDTO;
-import com.mankind.mankindmatrixuserservice.dto.UpdateUserDTO;
-import com.mankind.mankindmatrixuserservice.dto.UserDTO;
+import com.mankind.api.user.dto.AddressDTO;
+import com.mankind.api.user.dto.CreateAddressDTO;
+import com.mankind.api.user.dto.UpdateAddressDTO;
+import com.mankind.api.user.dto.UpdateUserDTO;
+import com.mankind.api.user.dto.UserDTO;
 import com.mankind.mankindmatrixuserservice.exception.AddressNotFoundException;
 import com.mankind.mankindmatrixuserservice.service.AddressService;
 import com.mankind.mankindmatrixuserservice.service.UserService;

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/mapper/AddressMapper.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/mapper/AddressMapper.java
@@ -1,8 +1,8 @@
 package com.mankind.mankindmatrixuserservice.mapper;
 
-import com.mankind.mankindmatrixuserservice.dto.AddressDTO;
-import com.mankind.mankindmatrixuserservice.dto.CreateAddressDTO;
-import com.mankind.mankindmatrixuserservice.dto.UpdateAddressDTO;
+import com.mankind.api.user.dto.AddressDTO;
+import com.mankind.api.user.dto.CreateAddressDTO;
+import com.mankind.api.user.dto.UpdateAddressDTO;
 import com.mankind.mankindmatrixuserservice.model.Address;
 import com.mankind.mankindmatrixuserservice.model.User;
 import org.springframework.stereotype.Component;

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/mapper/UserMapper.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/mapper/UserMapper.java
@@ -1,6 +1,6 @@
 package com.mankind.mankindmatrixuserservice.mapper;
 
-import com.mankind.mankindmatrixuserservice.dto.UserDTO;
+import com.mankind.api.user.dto.UserDTO;
 import com.mankind.mankindmatrixuserservice.model.User;
 import org.mapstruct.Mapper;
 

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/mapper/UserUpdateMapper.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/mapper/UserUpdateMapper.java
@@ -1,7 +1,7 @@
 package com.mankind.mankindmatrixuserservice.mapper;
 
 
-import com.mankind.mankindmatrixuserservice.dto.UpdateUserDTO;
+import com.mankind.api.user.dto.UpdateUserDTO;
 import com.mankind.mankindmatrixuserservice.model.User;
 import org.mapstruct.Mapper;
 

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/model/Address.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/model/Address.java
@@ -1,5 +1,6 @@
 package com.mankind.mankindmatrixuserservice.model;
 
+import com.mankind.api.user.enums.AddressType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -56,7 +57,4 @@ public class Address {
     @Column()
     private LocalDateTime updatedAt;
 
-    public enum AddressType {
-        billing, shipping
-    }
 }

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/model/User.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/model/User.java
@@ -1,5 +1,6 @@
 package com.mankind.mankindmatrixuserservice.model;
 
+import com.mankind.api.user.enums.Role;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/repository/AddressRepository.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/repository/AddressRepository.java
@@ -1,6 +1,7 @@
 package com.mankind.mankindmatrixuserservice.repository;
 
 import com.mankind.mankindmatrixuserservice.model.Address;
+import com.mankind.api.user.enums.AddressType;
 import com.mankind.mankindmatrixuserservice.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,6 +12,6 @@ import java.util.Optional;
 @Repository
 public interface AddressRepository extends JpaRepository<Address, Long> {
     List<Address> findByUser(User user);
-    List<Address> findByUserAndAddressType(User user, Address.AddressType addressType);
-    Optional<Address> findByUserAndIsDefaultAndAddressType(User user, Boolean isDefault, Address.AddressType addressType);
+    List<Address> findByUserAndAddressType(User user, AddressType addressType);
+    Optional<Address> findByUserAndIsDefaultAndAddressType(User user, Boolean isDefault, AddressType addressType);
 }

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/service/AddressService.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/service/AddressService.java
@@ -1,12 +1,13 @@
 package com.mankind.mankindmatrixuserservice.service;
 
-import com.mankind.mankindmatrixuserservice.dto.AddressDTO;
-import com.mankind.mankindmatrixuserservice.dto.CreateAddressDTO;
-import com.mankind.mankindmatrixuserservice.dto.UpdateAddressDTO;
+import com.mankind.api.user.dto.AddressDTO;
+import com.mankind.api.user.dto.CreateAddressDTO;
+import com.mankind.api.user.dto.UpdateAddressDTO;
 import com.mankind.mankindmatrixuserservice.exception.AddressNotFoundException;
 import com.mankind.mankindmatrixuserservice.exception.UserNotFoundException;
 import com.mankind.mankindmatrixuserservice.mapper.AddressMapper;
 import com.mankind.mankindmatrixuserservice.model.Address;
+import com.mankind.api.user.enums.AddressType;
 import com.mankind.mankindmatrixuserservice.model.User;
 import com.mankind.mankindmatrixuserservice.repository.AddressRepository;
 import com.mankind.mankindmatrixuserservice.repository.UserRepository;
@@ -74,7 +75,7 @@ public class AddressService {
 
         // If this is set as default, unset any existing default of the same type
         if (Boolean.TRUE.equals(updateAddressDTO.getIsDefault())) {
-            Address.AddressType addressType = updateAddressDTO.getAddressType() != null 
+            AddressType addressType = updateAddressDTO.getAddressType() != null
                     ? updateAddressDTO.getAddressType() 
                     : address.getAddressType();
 

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/service/UserService.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/service/UserService.java
@@ -1,13 +1,13 @@
 package com.mankind.mankindmatrixuserservice.service;
 
-import com.mankind.mankindmatrixuserservice.dto.AuthRequest;
-import com.mankind.mankindmatrixuserservice.dto.AuthResponse;
-import com.mankind.mankindmatrixuserservice.dto.UpdateUserDTO;
-import com.mankind.mankindmatrixuserservice.dto.UserDTO;
+import com.mankind.api.user.dto.AuthRequest;
+import com.mankind.api.user.dto.AuthResponse;
+import com.mankind.api.user.dto.UpdateUserDTO;
+import com.mankind.api.user.dto.UserDTO;
 import com.mankind.mankindmatrixuserservice.exception.UserNotFoundException;
 import com.mankind.mankindmatrixuserservice.mapper.UserMapper;
 import com.mankind.mankindmatrixuserservice.mapper.UserUpdateMapper;
-import com.mankind.mankindmatrixuserservice.model.Role;
+import com.mankind.api.user.enums.Role;
 import com.mankind.mankindmatrixuserservice.model.User;
 import com.mankind.mankindmatrixuserservice.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/wishlist-service/Dockerfile
+++ b/wishlist-service/Dockerfile
@@ -5,7 +5,10 @@ WORKDIR /build
 # Copy the entire project
 COPY . .
 
-# Build the application with explicit executable JAR creation
+# First, build and install the API modules to local repository
+RUN mvn clean install -pl user-api,product-api -am -DskipTests
+
+# Then build the wishlist service
 RUN cd wishlist-service && \
     mvn clean package spring-boot:repackage -DskipTests && \
     ls -la target/

--- a/wishlist-service/pom.xml
+++ b/wishlist-service/pom.xml
@@ -8,11 +8,9 @@
 		<version>1.0.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
-	<groupId>com.mankind.matrix</groupId>
 	<artifactId>wishlist-service</artifactId>
-	<version>0.0.1-SNAPSHOT</version>
 	<name>wishlist-service</name>
-	<description>Demo project for Spring Boot</description>
+	<description>Mankind Matrix Wishlist Service</description>
 	<url/>
 	<licenses>
 		<license/>
@@ -26,9 +24,6 @@
 		<tag/>
 		<url/>
 	</scm>
-	<properties>
-		<java.version>17</java.version>
-	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -38,7 +33,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-openfeign</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -84,6 +82,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+		<!-- API Modules-->
+		<dependency>
+			<groupId>com.mankind</groupId>
+			<artifactId>product-api</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/MatrixWishlishServiceApplication.java
+++ b/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/MatrixWishlishServiceApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 
 @SpringBootApplication
 @OpenAPIDefinition(
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.info.Info;
         description = "API documentation for the Mankind Matrix Wishlist Service"
     )
 )
+@EnableFeignClients
 public class MatrixWishlishServiceApplication {
 
 	public static void main(String[] args) {

--- a/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/client/ProductClient.java
+++ b/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/client/ProductClient.java
@@ -1,8 +1,13 @@
 package com.mankind.matrix_wishlistservice.client;
 
+import com.mankind.api.product.dto.product.ProductResponseDTO;
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @FeignClient(name = "product-service", url = "${product-service.url}")
 public interface ProductClient {
-
+    @GetMapping("/api/v1/products/{id}")
+    ResponseEntity<ProductResponseDTO> getProductById(@PathVariable Long id);
 }

--- a/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/client/ProductClient.java
+++ b/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/client/ProductClient.java
@@ -1,0 +1,8 @@
+package com.mankind.matrix_wishlistservice.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+
+@FeignClient(name = "product-service", url = "${product-service.url}")
+public interface ProductClient {
+
+}

--- a/wishlist-service/src/main/resources/application.yml
+++ b/wishlist-service/src/main/resources/application.yml
@@ -65,3 +65,5 @@ management:
       enabled: true
     readinessState:
       enabled: true
+product-service:
+  url: http://localhost:8080


### PR DESCRIPTION
## Summary
This PR pulls all shared DTOs into two new API modules—user-api and product-api—and updates each downstream service (user, product, cart, wishlist) to depend on its corresponding API module via Feign clients. Services now consume contracts instead of internal entity classes, paving the way for a clean gateway and service discovery integration.

## Changes

### New Modules

- Created `user-api` and `product-api` as standalone JARs containing only DTOs, enums, and validation annotations.

### Service POM Updates

- Added `com.mankind:user-api` or `com.mankind:product-api` dependencies to each service’s `pom.xml`.
- Removed internal DTO packages from `user-service`, and `product-service` creating a pattern for future changes.

### Feign Clients

- Introduced `UserClient` and `ProductClient` interfaces in each consuming service under `client/`.
- Configured a `RequestInterceptor` to propagate the incoming Authorization header for secure service-to-service calls.

### Security Adjustments

- Locked down all non-auth endpoints in user-service.
- No longer allow anonymous access to /api/v1/users—requests must carry a valid JWT forwarded by clients.

### Configuration

- Externalized each service’s peer-URL in application.yml (user-service.url, product-service.url).

