### PR TITLE
fix: added CORS setting on user-service

### DIFF
--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/config/WebConfig.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.mankind.mankindmatrixuserservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("*");
+            }
+        };
+    }
+} 


### PR DESCRIPTION
## Overview
This PR adds Cross-Origin Resource Sharing (CORS) configuration to the user-service to enable frontend applications to communicate with the backend API without encountering CORS policy violations.

## Changes Made

### Added Files
- `src/main/java/com/mankind/mankindmatrixuserservice/config/WebConfig.java` - New CORS configuration class

### Configuration Details
- **Allowed Origins**: `http://localhost:3000` (React development server)
- **Allowed Methods**: All HTTP methods (`*`)
- **Mapped Paths**: All endpoints (`/**`)

## Why This Change Was Needed

### Problem
- Frontend applications running on `localhost:3000` were unable to make requests to the user-service API
- Browser was blocking cross-origin requests due to missing CORS headers
- Error: `Access to XMLHttpRequest at 'http://localhost:8081/api/v1/auth/login' from origin 'http://localhost:3000' has been blocked by CORS policy`

### Solution
- Implemented the same CORS configuration pattern used in `product-service`
- Added `WebConfig` class with `WebMvcConfigurer` to handle CORS headers
- Configured to allow requests from the frontend development server
