### PR TITLE
Gateway Integration Fixes and Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,22 @@ You can choose your preferred method based on your needs. Docker is recommended 
    cd product-service
    ./mvnw clean install
    ```
+   Build Gateway
+   ```bash
+   cd mankind-gateway-service
+   mvn clean install
+   ```
+   > **Note:** The gateway service uses `mvn clean install` because it does not have a Maven Wrapper (`mvnw`). The other services use `mvn clean install` for consistency and portability.
 
-4. **Run Each Service**
+4. **Run the Services**
 
-   Enter each service folder and run the commands below:
-
+   **Recommended: Use the provided script (easiest method)**
+   ```bash
+   ./scripts/run-all-services.sh
+   ```
+   
+   **Alternative: Manual startup**
+   Enter each service folder and run it. 
    For example, run the user-service:
 
    ```bash
@@ -121,11 +132,20 @@ You can choose your preferred method based on your needs. Docker is recommended 
    ./mvnw spring-boot:run
    ```
 
+   Run Gateway
+   ```bash
+   cd mankind-gateway-service
+   mvn spring-boot:run
+   ```
+   > **Note:** The gateway service uses `mvn spring-boot:run` because it does not have a Maven Wrapper (`mvnw`). The other services use `./mvnw spring-boot:run` for consistency and portability.
+
+   **To stop all services:**
+   ```bash
+   ./scripts/stop-all-services.sh
+   ```
+
 ### Service Swagger documentation links:
-- Product Service: [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
-- User Service: [http://localhost:8081/swagger-ui/index.html](http://localhost:8081/swagger-ui/index.html)
-- Cart Service: [http://localhost:8082/swagger-ui/index.html](http://localhost:8082/swagger-ui/index.html)
-- Wishlist Service: [http://localhost:8083/swagger-ui/index.html](http://localhost:8083/swagger-ui/index.html)
+- Gateway: [http://localhost:8085](http://localhost:8085)
 
 ### Services documentation
 
@@ -226,10 +246,7 @@ Each service has its detailed documentation. Click on the service name to view i
    ```
 
 ### Service Swagger documentation links:
-- Product Service: [http://localhost:8080/swagger-ui/index.html](http://localhost:8080/swagger-ui/index.html)
-- User Service: [http://localhost:8081/swagger-ui/index.html](http://localhost:8081/swagger-ui/index.html)
-- Cart Service: [http://localhost:8082/swagger-ui/index.html](http://localhost:8082/swagger-ui/index.html)
-- Wishlist Service: [http://localhost:8083/swagger-ui/index.html](http://localhost:8083/swagger-ui/index.html)
+- Gateway: [http://localhost:8085](http://localhost:8085)
 
 
 ### Services documentation

--- a/cart-service/pom.xml
+++ b/cart-service/pom.xml
@@ -25,7 +25,7 @@
         <url/>
     </scm>
     <properties>
-        <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <!-- No mapstruct.version here, use parent -->
     </properties>
     <dependencies>
         <dependency>
@@ -56,7 +56,6 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.30</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -64,7 +63,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- API Modules-->
         <dependency>
             <groupId>com.mankind</groupId>
             <artifactId>product-api</artifactId>
@@ -77,12 +75,10 @@
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
-            <version>${mapstruct.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct-processor</artifactId>
-            <version>${mapstruct.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -95,7 +91,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
         </dependency>
 
         <dependency>

--- a/cart-service/src/main/java/com/mankind/matrix_cart_service/config/OpenApiConfig.java
+++ b/cart-service/src/main/java/com/mankind/matrix_cart_service/config/OpenApiConfig.java
@@ -1,9 +1,12 @@
 package com.mankind.matrix_cart_service.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,25 +15,37 @@ import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
 
     @Bean
-    public OpenAPI customOpenAPI() {
+    public OpenAPI cartServiceOpenAPI() {
         return new OpenAPI()
                 .info(new Info()
                         .title("Mankind Matrix Cart Service API")
-                        .description("API for managing shopping cart items in the Mankind Matrix platform")
+                        .description("API documentation for the Mankind Matrix Cart Service.")
                         .version("1.0.0")
                         .contact(new Contact()
                                 .name("Mankind Matrix Team")
                                 .email("support@mankindmatrix.com")
-                                .url("https://mankindmatrix.com"))
+                                .url("https://www.mankindmatrix.com"))
                         .license(new License()
-                                .name("Proprietary")
-                                .url("https://mankindmatrix.com/license")))
+                                .name("Apache 2.0")
+                                .url("https://www.apache.org/licenses/LICENSE-2.0")))
                 .servers(List.of(
                         new Server()
                                 .url("http://localhost:8082")
-                                .description("Local Development Server")
-                ));
+                                .description("Local Development Server (Direct Access)"),
+                        new Server()
+                                .url("http://localhost:8085/api/v1/cart")
+                                .description("Gateway Server (Through Gateway)")
+                ))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .name(SECURITY_SCHEME_NAME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("Enter JWT token with Bearer prefix, e.g. 'Bearer eyJhbGciOiJIUzI1NiJ9...'")));
     }
 }

--- a/cart-service/src/main/java/com/mankind/matrix_cart_service/config/WebConfig.java
+++ b/cart-service/src/main/java/com/mankind/matrix_cart_service/config/WebConfig.java
@@ -1,12 +1,6 @@
-package com.mankind.matrix_product_service.config;
+package com.mankind.matrix_cart_service.config;
 
-import feign.RequestInterceptor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.util.StringUtils;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -30,18 +24,4 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true)
                 .maxAge(3600);
     }
-
-    @Bean
-    public RequestInterceptor propagateBearerToken() {
-        return template -> {
-            ServletRequestAttributes attrs =
-                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-            if (attrs != null) {
-                String auth = attrs.getRequest().getHeader(HttpHeaders.AUTHORIZATION);
-                if (StringUtils.hasText(auth)) {
-                    template.header(HttpHeaders.AUTHORIZATION, auth);
-                }
-            }
-        };
-    }
-}
+} 

--- a/cart-service/src/main/java/com/mankind/matrix_cart_service/controller/CartController.java
+++ b/cart-service/src/main/java/com/mankind/matrix_cart_service/controller/CartController.java
@@ -13,7 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/carts")
+@RequestMapping("/carts")
 @RequiredArgsConstructor
 @Tag(name = "Cart API", description = "API for managing shopping carts")
 public class CartController {

--- a/cart-service/src/main/java/com/mankind/matrix_cart_service/controller/CartItemController.java
+++ b/cart-service/src/main/java/com/mankind/matrix_cart_service/controller/CartItemController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/cart-items")
+@RequestMapping("/cart-items")
 @RequiredArgsConstructor
 @Tag(name = "Cart Item API", description = "API for managing cart items")
 public class CartItemController {

--- a/cart-service/src/main/resources/application.yml
+++ b/cart-service/src/main/resources/application.yml
@@ -2,13 +2,18 @@ server:
   port: 8082
 springdoc:
   api-docs:
-    path: /api-docs
+    path: /v3/api-docs
+    enabled: true
   swagger-ui:
-    path: /swagger-ui.html
+    path: /swagger-ui
     operationsSorter: method
     tagsSorter: alpha
-    filter: true
+    tryItOutEnabled: true
   show-actuator: false
+  default-produces-media-type: application/json
+  default-consumes-media-type: application/json
+  packages-to-scan: com.mankind.matrix_cart_service.controller
+  paths-to-match: /**
 spring:
   datasource:
     url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:mankind_matrix_db}?connectTimeout=${DB_CONNECT_TIMEOUT:60000}&socketTimeout=${DB_SOCKET_TIMEOUT:60000}&useSSL=${DB_USE_SSL:false}&allowPublicKeyRetrieval=${DB_ALLOW_PUBLIC_KEY_RETRIEVAL:true}&serverTimezone=${DB_SERVER_TIMEZONE:UTC}&autoReconnect=${DB_AUTO_RECONNECT:true}&failOverReadOnly=${DB_FAIL_OVER_READ_ONLY:false}

--- a/cart-service/src/test/java/com/mankind/matrix_cart_service/controller/CartItemControllerValidationTest.java
+++ b/cart-service/src/test/java/com/mankind/matrix_cart_service/controller/CartItemControllerValidationTest.java
@@ -54,7 +54,7 @@ public class CartItemControllerValidationTest {
         String requestBody = objectMapper.writeValueAsString(invalidDto);
 
         // Act & Assert
-        mockMvc.perform(post("/api/cart-items")
+        mockMvc.perform(post("/cart-items")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
                 .andExpect(status().isBadRequest())
@@ -73,7 +73,7 @@ public class CartItemControllerValidationTest {
         String requestBody = objectMapper.writeValueAsString(invalidDto);
 
         // Act & Assert
-        mockMvc.perform(post("/api/cart-items")
+        mockMvc.perform(post("/cart-items")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
                 .andExpect(status().isBadRequest())
@@ -92,7 +92,7 @@ public class CartItemControllerValidationTest {
         String requestBody = objectMapper.writeValueAsString(invalidDto);
 
         // Act & Assert
-        mockMvc.perform(post("/api/cart-items")
+        mockMvc.perform(post("/cart-items")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
                 .andExpect(status().isBadRequest())
@@ -111,7 +111,7 @@ public class CartItemControllerValidationTest {
         String requestBody = objectMapper.writeValueAsString(invalidDto);
 
         // Act & Assert
-        mockMvc.perform(post("/api/cart-items")
+        mockMvc.perform(post("/cart-items")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
                 .andExpect(status().isBadRequest())
@@ -130,7 +130,7 @@ public class CartItemControllerValidationTest {
         String requestBody = objectMapper.writeValueAsString(invalidDto);
 
         // Act & Assert
-        mockMvc.perform(post("/api/cart-items")
+        mockMvc.perform(post("/cart-items")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
                 .andExpect(status().isBadRequest());
@@ -153,7 +153,7 @@ public class CartItemControllerValidationTest {
         when(cartItemService.createCartItem(any(CartItemRequestDto.class))).thenReturn(responseDto);
 
         // Act & Assert
-        mockMvc.perform(post("/api/cart-items")
+        mockMvc.perform(post("/cart-items")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
                 .andExpect(status().isCreated());

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,41 @@
 services:
+  gateway-service:
+    build:
+      context: .
+      dockerfile: mankind-gateway-service/Dockerfile
+      args:
+        MAVEN_OPTS: "-Xmx512m -XX:MaxMetaspaceSize=256m"
+    container_name: mankind-gateway-service
+    ports:
+      - "8085:8085"
+    environment:
+      - SPRING_PROFILES_ACTIVE=prod
+      - JAVA_OPTS=-Xms256m -Xmx512m -XX:MaxMetaspaceSize=256m
+      - USER_SERVICE_URL=http://mankind-user-service:8080
+      - PRODUCT_SERVICE_URL=http://mankind-product-service:8080
+      - CART_SERVICE_URL=http://mankind-cart-service:8080
+      - WISHLIST_SERVICE_URL=http://mankind-wishlist-service:8080
+    deploy:
+      resources:
+        limits:
+          memory: 768M
+        reservations:
+          memory: 512M
+    networks:
+      - mankind-network
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8085/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    restart: unless-stopped
+    depends_on:
+      - product-service
+      - user-service
+      - cart-service
+      - wishlist-service
+
   product-service:
     build:
       context: .

--- a/mankind-gateway-service/Dockerfile
+++ b/mankind-gateway-service/Dockerfile
@@ -1,0 +1,30 @@
+# Build stage
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /build
+
+# Copy the entire project
+COPY . .
+
+# First, build and install the API modules to local repository
+RUN mvn clean install -pl user-api,product-api -am -DskipTests
+
+# Then build the gateway service
+RUN cd mankind-gateway-service && \
+    mvn clean package spring-boot:repackage -DskipTests && \
+    ls -la target/
+
+# Run stage
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+
+# Copy the built jar from build stage
+COPY --from=build /build/mankind-gateway-service/target/*.jar app.jar
+
+# Set environment variables
+ENV JAVA_OPTS="-Xms512m -Xmx1024m"
+
+# Expose the application port
+EXPOSE 8085
+
+# Run the application
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar app.jar"] 

--- a/mankind-gateway-service/README.md
+++ b/mankind-gateway-service/README.md
@@ -7,8 +7,8 @@ The Mankind API Gateway Service acts as the single entry point for all client re
 
 * Java 17+
 * Maven 3.6+
-* Spring Boot 3.2.x
-* Spring Cloud Gateway 4.1.x
+* Spring Boot 3.4.x
+* Spring Cloud Gateway 2024.0.x
 * (Optional) Docker & Docker Compose for containerized run
 
 ## Running the Gateway
@@ -95,3 +95,53 @@ To expose a new service endpoint via the gateway:
 3. Ensure the downstream service is registered in your discovery mechanism (e.g., Eureka).
 
 No additional code changes are needed in the gateway for simple routing.
+
+### Adding Swagger Documentation
+
+To enable Swagger documentation access through the gateway for a new service, add these additional routes:
+
+```yaml
+# API Documentation (OpenAPI JSON)
+- id: order-api-docs-root
+  uri: http://localhost:8084
+  predicates:
+    - Path=/order-api-docs
+  filters:
+    - SetPath=/v3/api-docs
+
+- id: order-api-docs
+  uri: http://localhost:8084
+  predicates:
+    - Path=/order-api-docs/**
+  filters:
+    - RewritePath=/order-api-docs/(?<segment>.*), /v3/api-docs/${segment}
+
+# Swagger UI
+- id: order-swagger-ui-root
+  uri: http://localhost:8084
+  predicates:
+    - Path=/docs/orders
+  filters:
+    - SetPath=/swagger-ui/index.html
+
+- id: order-swagger-ui-static
+  uri: http://localhost:8084
+  predicates:
+    - Path=/docs/orders/**
+  filters:
+    - RewritePath=/docs/orders/(?<segment>.*), /swagger-ui/${segment}
+```
+
+### Available Swagger Documentation URLs
+
+#### Swagger UI Access
+- **Product Service:** `http://localhost:8085/docs/products`
+- **Cart Service:** `http://localhost:8085/docs/cart`
+- **User Service:** `http://localhost:8085/docs/users`
+- **Wishlist Service:** `http://localhost:8085/docs/wishlist`
+
+#### API Documentation (OpenAPI JSON)
+- **Product Service:** `http://localhost:8085/product-api-docs`
+- **Cart Service:** `http://localhost:8085/cart-api-docs`
+- **User Service:** `http://localhost:8085/user-api-docs`
+- **Wishlist Service:** `http://localhost:8085/wishlist-api-docs`

--- a/mankind-gateway-service/src/main/resources/application.yml
+++ b/mankind-gateway-service/src/main/resources/application.yml
@@ -13,39 +13,59 @@ spring:
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://localhost:3000"
-            allowedMethods: GET,POST,PUT,DELETE,OPTIONS
+            allowedOrigins: 
+              - "http://localhost:3000"
+              - "http://localhost:8085"
+              - "http://127.0.0.1:8085"
+              - "http://localhost:8080"
+              - "http://localhost:8081"
+              - "http://localhost:8082"
+              - "http://localhost:8083"
+            allowedMethods: GET,POST,PUT,DELETE,OPTIONS,PATCH
+            allowedHeaders: "*"
+            allowCredentials: true
+            maxAge: 3600
 
       default-filters:
         - DedupeResponseHeader=Access-Control-Allow-Origin,RETAIN_UNIQUE
         - DedupeResponseHeader=Access-Control-Allow-Credentials,RETAIN_UNIQUE
 
       routes:
+        # API routes
         - id: auth
           uri: http://localhost:8081
           predicates:
             - Path=/api/v1/auth/**
+          filters:
+            - RewritePath=/api/v1/auth/(?<segment>.*), /auth/${segment}
 
         - id: users
           uri: http://localhost:8081
           predicates:
             - Path=/api/v1/users/**
+          filters:
+            - RewritePath=/api/v1/users/(?<segment>.*), /users/${segment}
           
         - id: products
           uri: http://localhost:8080
           predicates:
             - Path=/api/v1/products/**
+          filters:
+            - RewritePath=/api/v1/products/(?<segment>.*), /${segment}
           
         - id: cart
           uri: http://localhost:8082
           predicates:
             - Path=/api/v1/cart/**
+          filters:
+            - RewritePath=/api/v1/cart/(?<segment>.*), /cart/${segment}
           
         - id: wishlist
           uri: http://localhost:8083
           predicates:
             - Path=/api/v1/wishlist/**
-          
+          filters:
+            - RewritePath=/api/v1/wishlist/(?<segment>.*), /wishlist/${segment}
 
   security:
     oauth2:

--- a/mankind-gateway-service/src/main/resources/application.yml
+++ b/mankind-gateway-service/src/main/resources/application.yml
@@ -33,35 +33,35 @@ spring:
       routes:
         # API routes
         - id: auth
-          uri: http://localhost:8081
+          uri: ${USER_SERVICE_URL:http://localhost:8081}
           predicates:
             - Path=/api/v1/auth/**
           filters:
             - RewritePath=/api/v1/auth/(?<segment>.*), /auth/${segment}
 
         - id: users
-          uri: http://localhost:8081
+          uri: ${USER_SERVICE_URL:http://localhost:8081}
           predicates:
             - Path=/api/v1/users/**
           filters:
             - RewritePath=/api/v1/users/(?<segment>.*), /users/${segment}
           
         - id: products
-          uri: http://localhost:8080
+          uri: ${PRODUCT_SERVICE_URL:http://localhost:8080}
           predicates:
             - Path=/api/v1/products/**
           filters:
             - RewritePath=/api/v1/products/(?<segment>.*), /${segment}
           
         - id: cart
-          uri: http://localhost:8082
+          uri: ${CART_SERVICE_URL:http://localhost:8082}
           predicates:
             - Path=/api/v1/cart/**
           filters:
             - RewritePath=/api/v1/cart/(?<segment>.*), /cart/${segment}
           
         - id: wishlist
-          uri: http://localhost:8083
+          uri: ${WISHLIST_SERVICE_URL:http://localhost:8083}
           predicates:
             - Path=/api/v1/wishlist/**
           filters:
@@ -71,7 +71,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: http://localhost:8081/realms/mankind
+          issuer-uri: ${USER_SERVICE_URL:http://localhost:8081}/realms/mankind
 
 server:
   port: 8085

--- a/mankind-gateway-service/src/main/resources/static/index.html
+++ b/mankind-gateway-service/src/main/resources/static/index.html
@@ -1,0 +1,344 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mankind Matrix AI - API Gateway</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            color: #333;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+
+        .header {
+            text-align: center;
+            margin-bottom: 50px;
+            color: white;
+        }
+
+        .header h1 {
+            font-size: 3rem;
+            margin-bottom: 10px;
+            text-shadow: 2px 2px 4px rgba(0,0,0,0.3);
+        }
+
+        .header p {
+            font-size: 1.2rem;
+            opacity: 0.9;
+        }
+
+        .services-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+            gap: 30px;
+            margin-bottom: 50px;
+        }
+
+        .service-card {
+            background: white;
+            border-radius: 15px;
+            padding: 30px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.1);
+            transition: transform 0.3s ease, box-shadow 0.3s ease;
+        }
+
+        .service-card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 15px 40px rgba(0,0,0,0.2);
+        }
+
+        .service-header {
+            display: flex;
+            align-items: center;
+            margin-bottom: 20px;
+        }
+
+        .service-icon {
+            width: 50px;
+            height: 50px;
+            border-radius: 10px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin-right: 15px;
+            font-size: 1.5rem;
+            color: white;
+        }
+
+        .product-icon { background: linear-gradient(45deg, #ff6b6b, #ee5a24); }
+        .cart-icon { background: linear-gradient(45deg, #4834d4, #686de0); }
+        .user-icon { background: linear-gradient(45deg, #00d2d3, #54a0ff); }
+        .wishlist-icon { background: linear-gradient(45deg, #ff9ff3, #f368e0); }
+
+        .service-title {
+            font-size: 1.5rem;
+            font-weight: 600;
+            color: #333;
+        }
+
+        .service-description {
+            color: #666;
+            margin-bottom: 25px;
+            line-height: 1.6;
+        }
+
+        .links-section {
+            margin-bottom: 20px;
+        }
+
+        .section-title {
+            font-size: 1.1rem;
+            font-weight: 600;
+            margin-bottom: 10px;
+            color: #333;
+            display: flex;
+            align-items: center;
+        }
+
+        .section-title::before {
+            content: "🔗";
+            margin-right: 8px;
+        }
+
+        .link-item {
+            display: flex;
+            align-items: center;
+            margin-bottom: 8px;
+            padding: 8px 12px;
+            background: #f8f9fa;
+            border-radius: 8px;
+            transition: background 0.3s ease;
+        }
+
+        .link-item:hover {
+            background: #e9ecef;
+        }
+
+        .link-label {
+            font-weight: 500;
+            margin-right: 10px;
+            min-width: 80px;
+        }
+
+        .link-url {
+            color: #007bff;
+            text-decoration: none;
+            font-family: 'Courier New', monospace;
+            font-size: 0.9rem;
+            word-break: break-all;
+        }
+
+        .link-url:hover {
+            text-decoration: underline;
+        }
+
+        .footer {
+            text-align: center;
+            color: white;
+            margin-top: 50px;
+            padding: 20px;
+            opacity: 0.8;
+        }
+
+        .status-indicator {
+            display: inline-block;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: #28a745;
+            margin-right: 8px;
+            animation: pulse 2s infinite;
+        }
+
+        @keyframes pulse {
+            0% { opacity: 1; }
+            50% { opacity: 0.5; }
+            100% { opacity: 1; }
+        }
+
+        @media (max-width: 768px) {
+            .header h1 {
+                font-size: 2rem;
+            }
+            
+            .services-grid {
+                grid-template-columns: 1fr;
+            }
+            
+            .service-card {
+                padding: 20px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>🚀 Mankind Matrix</h1>
+            <p>API Gateway - Centralized Access to All Microservices</p>
+            <div style="margin-top: 10px;">
+                <span class="status-indicator"></span>
+                <span>Gateway Status: Online</span>
+            </div>
+        </div>
+
+        <div class="services-grid">
+            <!-- Product Service -->
+            <div class="service-card">
+                <div class="service-header">
+                    <div class="service-icon product-icon">📦</div>
+                    <h2 class="service-title">Product Service</h2>
+                </div>
+                <p class="service-description">
+                    Manage product catalog, inventory, categories, and recently viewed products.
+                </p>
+                
+                <div class="links-section">
+                    <h3 class="section-title">Swagger Documentation</h3>
+                    <div class="link-item">
+                        <span class="link-label">Docs:</span>
+                        <a href="http://localhost:8080/swagger-ui/index.html" class="link-url" target="_blank">http://localhost:8080/swagger-ui/index.html</a>
+                    </div>
+                </div>
+
+                <div class="links-section">
+                    <h3 class="section-title">API Access</h3>
+                    <div class="link-item">
+                        <span class="link-label">Base:</span>
+                        <a href="/api/v1/products" class="link-url" target="_blank">http://localhost:8085/api/v1/products</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Cart Service -->
+            <div class="service-card">
+                <div class="service-header">
+                    <div class="service-icon cart-icon">🛒</div>
+                    <h2 class="service-title">Cart Service</h2>
+                </div>
+                <p class="service-description">
+                    Handle shopping cart operations, cart items, and cart status management.
+                </p>
+                
+                <div class="links-section">
+                    <h3 class="section-title">Swagger Documentation</h3>
+                    <div class="link-item">
+                        <span class="link-label">Docs:</span>
+                        <a href="http://localhost:8082/swagger-ui/index.html" class="link-url" target="_blank">http://localhost:8082/swagger-ui/index.html</a>
+                    </div>
+                </div>
+
+                <div class="links-section">
+                    <h3 class="section-title">API Access</h3>
+                    <div class="link-item">
+                        <span class="link-label">Base:</span>
+                        <a href="/api/v1/cart" class="link-url" target="_blank">http://localhost:8085/api/v1/cart</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- User Service -->
+            <div class="service-card">
+                <div class="service-header">
+                    <div class="service-icon user-icon">👤</div>
+                    <h2 class="service-title">User Service</h2>
+                </div>
+                <p class="service-description">
+                    User authentication, registration, profile management, and address handling.
+                </p>
+                
+                <div class="links-section">
+                    <h3 class="section-title">Swagger Documentation</h3>
+                    <div class="link-item">
+                        <span class="link-label">Docs:</span>
+                        <a href="http://localhost:8081/swagger-ui/index.html" class="link-url" target="_blank">http://localhost:8081/swagger-ui/index.html</a>
+                    </div>
+                </div>
+
+                <div class="links-section">
+                    <h3 class="section-title">API Access</h3>
+                    <div class="link-item">
+                        <span class="link-label">Auth:</span>
+                        <a href="/api/v1/auth" class="link-url" target="_blank">http://localhost:8085/api/v1/auth</a>
+                    </div>
+                    <div class="link-item">
+                        <span class="link-label">Users:</span>
+                        <a href="/api/v1/users" class="link-url" target="_blank">http://localhost:8085/api/v1/users</a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Wishlist Service -->
+            <div class="service-card">
+                <div class="service-header">
+                    <div class="service-icon wishlist-icon">❤️</div>
+                    <h2 class="service-title">Wishlist Service</h2>
+                </div>
+                <p class="service-description">
+                    Manage user wishlists, add/remove items, and wishlist operations.
+                </p>
+                
+                <div class="links-section">
+                    <h3 class="section-title">Swagger Documentation</h3>
+                    <div class="link-item">
+                        <span class="link-label">Docs:</span>
+                        <a href="http://localhost:8083/swagger-ui/index.html" class="link-url" target="_blank">http://localhost:8083/swagger-ui/index.html</a>
+                    </div>
+                </div>
+
+                <div class="links-section">
+                    <h3 class="section-title">API Access</h3>
+                    <div class="link-item">
+                        <span class="link-label">Base:</span>
+                        <a href="/api/v1/wishlist" class="link-url" target="_blank">http://localhost:8085/api/v1/wishlist</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="footer">
+            <p>&copy; 2024 Mankind Matrix AI. All rights reserved.</p>
+            <p style="margin-top: 10px; font-size: 0.9rem;">
+                Built with Spring Cloud Gateway | Microservices Architecture
+            </p>
+        </div>
+    </div>
+
+    <script>
+        // Add some interactivity
+        document.addEventListener('DOMContentLoaded', function() {
+            // Add click tracking for analytics (optional)
+            const links = document.querySelectorAll('.link-url');
+            links.forEach(link => {
+                link.addEventListener('click', function() {
+                    console.log('Link clicked:', this.href);
+                });
+            });
+
+            // Add smooth scrolling for better UX
+            document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+                anchor.addEventListener('click', function (e) {
+                    e.preventDefault();
+                    document.querySelector(this.getAttribute('href')).scrollIntoView({
+                        behavior: 'smooth'
+                    });
+                });
+            });
+        });
+    </script>
+</body>
+</html> 

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
     <spring.boot.version>3.4.4</spring.boot.version>
     <springframework.cloud.version>2024.0.1</springframework.cloud.version>
     <lombok.version>1.18.30</lombok.version>
+    <springdoc.version>2.8.9</springdoc.version>
+    <mapstruct.version>1.5.5.Final</mapstruct.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -53,6 +55,24 @@
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>${lombok.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <!-- SpringDoc OpenAPI Dependencies -->
+      <dependency>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+        <version>${springdoc.version}</version>
+      </dependency>
+      <!-- MapStruct Dependencies -->
+      <dependency>
+        <groupId>org.mapstruct</groupId>
+        <artifactId>mapstruct</artifactId>
+        <version>${mapstruct.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mapstruct</groupId>
+        <artifactId>mapstruct-processor</artifactId>
+        <version>${mapstruct.version}</version>
         <scope>provided</scope>
       </dependency>
     </dependencies>

--- a/product-api/pom.xml
+++ b/product-api/pom.xml
@@ -22,7 +22,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/product-service/pom.xml
+++ b/product-service/pom.xml
@@ -25,7 +25,7 @@
         <url/>
     </scm>
     <properties>
-        <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <!-- No mapstruct.version here, use parent -->
     </properties>
     <dependencies>
         <dependency>
@@ -74,12 +74,10 @@
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
-            <version>${mapstruct.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct-processor</artifactId>
-            <version>${mapstruct.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -92,7 +90,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
         </dependency>
 
         <!-- Spring Boot Actuator -->

--- a/product-service/src/main/java/com/mankind/matrix_product_service/config/OpenApiConfig.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/config/OpenApiConfig.java
@@ -1,9 +1,12 @@
 package com.mankind.matrix_product_service.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -12,27 +15,37 @@ import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
 
     @Bean
     public OpenAPI productServiceOpenAPI() {
         return new OpenAPI()
                 .info(new Info()
                         .title("Mankind Matrix Product Service API")
-                        .description("API for managing products in the Mankind Matrix system")
-                        .version("1.0")
+                        .description("API documentation for the Mankind Matrix Product Service.")
+                        .version("1.0.0")
                         .contact(new Contact()
-                                .name("Mankind Team")
-                                .email("support@mankind.com"))
+                                .name("Mankind Matrix Team")
+                                .email("support@mankindmatrix.com")
+                                .url("https://www.mankindmatrix.com"))
                         .license(new License()
-                                .name("Proprietary")
-                                .url("https://mankind.com/license")))
+                                .name("Apache 2.0")
+                                .url("https://www.apache.org/licenses/LICENSE-2.0")))
                 .servers(List.of(
                         new Server()
                                 .url("http://localhost:8080")
-                                .description("Local Development Server"),
+                                .description("Local Development Server (Direct Access)"),
                         new Server()
-                                .url("https://api.mankind.com")
-                                .description("Production Server")
-                ));
+                                .url("http://localhost:8085/api/v1/products")
+                                .description("Gateway Server (Through Gateway)")
+                ))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .name(SECURITY_SCHEME_NAME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("Enter JWT token with Bearer prefix, e.g. 'Bearer eyJhbGciOiJIUzI1NiJ9...'")));
     }
 } 

--- a/product-service/src/main/java/com/mankind/matrix_product_service/controller/CategoryController.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/controller/CategoryController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/categories")
+@RequestMapping("/categories")
 @RequiredArgsConstructor
 @Tag(name = "Category Management", description = "APIs for managing product categories")
 public class CategoryController {

--- a/product-service/src/main/java/com/mankind/matrix_product_service/controller/InventoryController.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/controller/InventoryController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/inventory")
+@RequestMapping("/inventory")
 @RequiredArgsConstructor
 @Tag(name = "Inventory", description = "Inventory management APIs")
 public class InventoryController {

--- a/product-service/src/main/java/com/mankind/matrix_product_service/controller/ProductController.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/controller/ProductController.java
@@ -20,7 +20,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/products")
+@RequestMapping("/products")
 @RequiredArgsConstructor
 @Tag(name = "Product Management", description = "APIs for managing products")
 public class ProductController {

--- a/product-service/src/main/java/com/mankind/matrix_product_service/controller/RecentlyViewedProductController.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/controller/RecentlyViewedProductController.java
@@ -16,7 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/recently-viewed")
+@RequestMapping("/recently-viewed")
 @RequiredArgsConstructor
 @Tag(name = "Recently Viewed Products", description = "APIs for managing recently viewed products")
 public class RecentlyViewedProductController {

--- a/product-service/src/main/java/com/mankind/matrix_product_service/controller/ReviewController.java
+++ b/product-service/src/main/java/com/mankind/matrix_product_service/controller/ReviewController.java
@@ -3,44 +3,95 @@ package com.mankind.matrix_product_service.controller;
 import com.mankind.api.product.dto.review.CreateReviewDTO;
 import com.mankind.api.product.dto.review.ReviewDTO;
 import com.mankind.matrix_product_service.service.ReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/reviews")
+@RequestMapping("/reviews")
+@RequiredArgsConstructor
+@Tag(name = "Review Management", description = "APIs for managing product reviews")
 public class ReviewController {
 
-    @Autowired
-    private ReviewService reviewService;
+    private final ReviewService reviewService;
 
+    @Operation(summary = "Create a new review", description = "Creates a new review for a product")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Review successfully created",
+                    content = @Content(schema = @Schema(implementation = ReviewDTO.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
     @PostMapping
-    public ResponseEntity<ReviewDTO> createReview(@Valid @RequestBody CreateReviewDTO createReviewDTO) {
+    public ResponseEntity<ReviewDTO> createReview(
+            @Parameter(description = "Review object to be created", required = true)
+            @Valid @RequestBody CreateReviewDTO createReviewDTO) {
         return ResponseEntity.ok(reviewService.createReview(createReviewDTO));
     }
 
+    @Operation(summary = "Get reviews by product ID", description = "Retrieves all reviews for a specific product")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved reviews",
+                    content = @Content(schema = @Schema(implementation = ReviewDTO.class))),
+        @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
     @GetMapping("/product/{productId}")
-    public ResponseEntity<List<ReviewDTO>> getReviewsByProductId(@PathVariable Long productId) {
+    public ResponseEntity<List<ReviewDTO>> getReviewsByProductId(
+            @Parameter(description = "ID of the product", required = true)
+            @PathVariable Long productId) {
         return ResponseEntity.ok(reviewService.getReviewsByProductId(productId));
     }
 
+    @Operation(summary = "Get reviews by user ID", description = "Retrieves all reviews by a specific user")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved reviews",
+                    content = @Content(schema = @Schema(implementation = ReviewDTO.class))),
+        @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
     @GetMapping("/user/{userId}")
-    public ResponseEntity<List<ReviewDTO>> getReviewsByUserId(@PathVariable Long userId) {
+    public ResponseEntity<List<ReviewDTO>> getReviewsByUserId(
+            @Parameter(description = "ID of the user", required = true)
+            @PathVariable Long userId) {
         return ResponseEntity.ok(reviewService.getReviewsByUserId(userId));
     }
 
+    @Operation(summary = "Update review", description = "Updates an existing review")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Review successfully updated",
+                    content = @Content(schema = @Schema(implementation = ReviewDTO.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid input"),
+        @ApiResponse(responseCode = "404", description = "Review not found"),
+        @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
     @PutMapping("/{reviewId}")
     public ResponseEntity<ReviewDTO> updateReview(
+            @Parameter(description = "ID of the review to update", required = true)
             @PathVariable Long reviewId,
+            @Parameter(description = "Updated review object", required = true)
             @Valid @RequestBody CreateReviewDTO createReviewDTO) {
         return ResponseEntity.ok(reviewService.updateReview(reviewId, createReviewDTO));
     }
 
+    @Operation(summary = "Delete review", description = "Deletes a review")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Review successfully deleted"),
+        @ApiResponse(responseCode = "404", description = "Review not found"),
+        @ApiResponse(responseCode = "500", description = "Internal server error")
+    })
     @DeleteMapping("/{reviewId}")
-    public ResponseEntity<Void> deleteReview(@PathVariable Long reviewId) {
+    public ResponseEntity<Void> deleteReview(
+            @Parameter(description = "ID of the review to delete", required = true)
+            @PathVariable Long reviewId) {
         reviewService.deleteReview(reviewId);
         return ResponseEntity.ok().build();
     }

--- a/product-service/src/main/resources/application.yml
+++ b/product-service/src/main/resources/application.yml
@@ -1,5 +1,22 @@
 server:
   port: 8080
+
+# Swagger/OpenAPI Configuration
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+    enabled: true
+  swagger-ui:
+    path: /swagger-ui
+    operationsSorter: method
+    tagsSorter: alpha
+    tryItOutEnabled: true
+  show-actuator: false
+  default-produces-media-type: application/json
+  default-consumes-media-type: application/json
+  packages-to-scan: com.mankind.matrix_product_service.controller
+  paths-to-match: /**
+
 spring:
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?connectTimeout=${DB_CONNECT_TIMEOUT}&socketTimeout=${DB_SOCKET_TIMEOUT}&useSSL=${DB_USE_SSL}&allowPublicKeyRetrieval=${DB_ALLOW_PUBLIC_KEY_RETRIEVAL}&serverTimezone=${DB_SERVER_TIMEZONE}&autoReconnect=${DB_AUTO_RECONNECT}&failOverReadOnly=${DB_FAIL_OVER_READ_ONLY}

--- a/scripts/run-all-services.sh
+++ b/scripts/run-all-services.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# Mankind Matrix AI Backend - All Services Startup Script
+# This script kills any existing processes on the service ports and starts all microservices
+
+echo "🚀 Starting Mankind Matrix AI Backend Services..."
+
+# Ports used by the services
+PORTS=(8080 8081 8082 8083 8085)
+
+# Kill any process using the service ports
+echo "🔧 Cleaning up ports..."
+for port in "${PORTS[@]}"; do
+  PID=$(lsof -ti tcp:$port)
+  if [ -n "$PID" ]; then
+    echo "   Killing process on port $port (PID $PID)"
+    kill -9 $PID 2>/dev/null
+  else
+    echo "   Port $port is free"
+  fi
+done
+
+echo ""
+echo "📦 Starting microservices..."
+
+# Start microservices in the background
+echo "   Starting user-service on port 8081..."
+( cd user-service && ./mvnw spring-boot:run > /dev/null 2>&1 & )
+
+echo "   Starting product-service on port 8080..."
+( cd product-service && ./mvnw spring-boot:run > /dev/null 2>&1 & )
+
+echo "   Starting cart-service on port 8082..."
+( cd cart-service && ./mvnw spring-boot:run > /dev/null 2>&1 & )
+
+echo "   Starting wishlist-service on port 8083..."
+( cd wishlist-service && ./mvnw spring-boot:run > /dev/null 2>&1 & )
+
+echo ""
+echo "⏳ Waiting 15 seconds for services to initialize..."
+sleep 15
+
+echo ""
+echo "🌐 Starting gateway service on port 8085..."
+( cd mankind-gateway-service && mvn spring-boot:run > /dev/null 2>&1 & )
+
+echo ""
+echo "✅ All services started successfully!"
+echo ""
+echo "📋 Service URLs:"
+echo "   Product Service: http://localhost:8080/swagger-ui/index.html"
+echo "   User Service:    http://localhost:8081/swagger-ui/index.html"
+echo "   Cart Service:    http://localhost:8082/swagger-ui/index.html"
+echo "   Wishlist Service: http://localhost:8083/swagger-ui/index.html"
+echo "   Gateway Service: http://localhost:8085"
+echo ""
+echo "💡 To stop all services, run: ./scripts/stop-all-services.sh" 

--- a/scripts/stop-all-services.sh
+++ b/scripts/stop-all-services.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Mankind Matrix AI Backend - Stop All Services Script
+# This script stops all running microservices by killing processes on their ports
+
+echo "🛑 Stopping Mankind Matrix AI Backend Services..."
+
+# Ports used by the services
+PORTS=(8080 8081 8082 8083 8085)
+
+# Kill any process using the service ports
+for port in "${PORTS[@]}"; do
+  PID=$(lsof -ti tcp:$port)
+  if [ -n "$PID" ]; then
+    echo "   Stopping service on port $port (PID $PID)"
+    kill -9 $PID 2>/dev/null
+  else
+    echo "   No service running on port $port"
+  fi
+done
+
+echo ""
+echo "✅ All services stopped successfully!" 

--- a/user-service/pom.xml
+++ b/user-service/pom.xml
@@ -25,7 +25,7 @@
         <url/>
     </scm>
     <properties>
-        <mapstruct.version>1.5.5.Final</mapstruct.version>
+        <!-- No mapstruct.version here, use parent -->
     </properties>
     <dependencies>
         <dependency>
@@ -74,12 +74,10 @@
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
-            <version>${mapstruct.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct-processor</artifactId>
-            <version>${mapstruct.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -109,14 +107,6 @@
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
-        </dependency>
-
-        <!-- SpringDoc OpenAPI (Swagger) dependencies -->
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-            <version>2.3.0</version>
         </dependency>
 
         <!-- Spring Boot Actuator -->

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/config/OpenApiConfig.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/config/OpenApiConfig.java
@@ -7,8 +7,11 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
@@ -19,8 +22,8 @@ public class OpenApiConfig {
     public OpenAPI userServiceOpenAPI() {
         return new OpenAPI()
                 .info(new Info()
-                        .title("Mankind_Matrix AI")
-                        .description("API documentation for the Mankind Matrix User Service")
+                        .title("Mankind Matrix User Service API")
+                        .description("API documentation for the Mankind Matrix User Service.")
                         .version("1.0.0")
                         .contact(new Contact()
                                 .name("Mankind Matrix Team")
@@ -29,6 +32,14 @@ public class OpenApiConfig {
                         .license(new License()
                                 .name("Apache 2.0")
                                 .url("https://www.apache.org/licenses/LICENSE-2.0")))
+                .servers(List.of(
+                        new Server()
+                                .url("http://localhost:8081")
+                                .description("Local Development Server (Direct Access)"),
+                        new Server()
+                                .url("http://localhost:8085/api/v1/users")
+                                .description("Gateway Server (Through Gateway)")
+                ))
                 .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
                 .components(new Components()
                         .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/config/WebConfig.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/config/WebConfig.java
@@ -1,12 +1,6 @@
-package com.mankind.matrix_product_service.config;
+package com.mankind.mankindmatrixuserservice.config;
 
-import feign.RequestInterceptor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.util.StringUtils;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -30,18 +24,4 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true)
                 .maxAge(3600);
     }
-
-    @Bean
-    public RequestInterceptor propagateBearerToken() {
-        return template -> {
-            ServletRequestAttributes attrs =
-                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-            if (attrs != null) {
-                String auth = attrs.getRequest().getHeader(HttpHeaders.AUTHORIZATION);
-                if (StringUtils.hasText(auth)) {
-                    template.header(HttpHeaders.AUTHORIZATION, auth);
-                }
-            }
-        };
-    }
-}
+} 

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/controller/AuthController.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/controller/AuthController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/auth")
 @Tag(name = "Authentication", description = "API endpoints for user registration and authentication")
 public class AuthController {
 

--- a/user-service/src/main/java/com/mankind/mankindmatrixuserservice/controller/UserController.java
+++ b/user-service/src/main/java/com/mankind/mankindmatrixuserservice/controller/UserController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/users")
+@RequestMapping("/users")
 @Tag(name = "User Management", description = "API endpoints for managing users and their addresses")
 public class UserController {
 

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -36,12 +36,17 @@ jwt:
 springdoc:
   api-docs:
     path: /v3/api-docs
+    enabled: true
   swagger-ui:
-    path: /swagger-ui.html
+    path: /swagger-ui
     operationsSorter: method
     tagsSorter: alpha
     tryItOutEnabled: true
+  show-actuator: false
+  default-produces-media-type: application/json
+  default-consumes-media-type: application/json
   packages-to-scan: com.mankind.mankindmatrixuserservice.controller
+  paths-to-match: /**
 
 management:
   endpoints:

--- a/wishlist-service/pom.xml
+++ b/wishlist-service/pom.xml
@@ -63,7 +63,6 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.3.0</version>
 		</dependency>
 
 		<dependency>

--- a/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/client/ProductClient.java
+++ b/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/client/ProductClient.java
@@ -8,6 +8,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 
 @FeignClient(name = "product-service", url = "${product-service.url}")
 public interface ProductClient {
-    @GetMapping("/api/v1/products/{id}")
+    @GetMapping("/products/{id}")
     ResponseEntity<ProductResponseDTO> getProductById(@PathVariable Long id);
 }

--- a/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/config/OpenApiConfig.java
+++ b/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/config/OpenApiConfig.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.models.GroupedOpenApi;
@@ -15,12 +16,13 @@ import java.util.List;
 
 @Configuration
 public class OpenApiConfig {
+    private static final String SECURITY_SCHEME_NAME = "bearerAuth";
 
     @Bean
     public GroupedOpenApi publicApi() {
         return GroupedOpenApi.builder()
                 .group("wishlist-public")
-                .pathsToMatch("/api/**")
+                .pathsToMatch("/**")
                 .build();
     }
 
@@ -28,17 +30,8 @@ public class OpenApiConfig {
     public OpenAPI wishlistServiceOpenAPI() {
         return new OpenAPI()
                 .info(new Info()
-                        .title("Wishlist Service API")
-                        .description("""
-                            API documentation for the Mankind Matrix Wishlist Service.
-                            This service provides endpoints for managing user wishlists, allowing users to:
-                            - Add products to their wishlist
-                            - Remove products from their wishlist
-                            - View their wishlist
-                            - Check if a product is in their wishlist
-                            
-                            All endpoints are prefixed with `/api/wishlist`.
-                            """)
+                        .title("Mankind Matrix Wishlist Service API")
+                        .description("API documentation for the Mankind Matrix Wishlist Service.")
                         .version("1.0.0")
                         .contact(new Contact()
                                 .name("Mankind Matrix Team")
@@ -48,19 +41,20 @@ public class OpenApiConfig {
                                 .name("Apache 2.0")
                                 .url("https://www.apache.org/licenses/LICENSE-2.0")))
                 .servers(List.of(
-                    new Server()
-                        .url("http://localhost:8083")
-                        .description("Local Development Server"),
-                    new Server()
-                        .url("https://api.mankindmatrix.com")
-                        .description("Production Server")
+                        new Server()
+                                .url("http://localhost:8083")
+                                .description("Local Development Server (Direct Access)"),
+                        new Server()
+                                .url("http://localhost:8085/api/v1/wishlist")
+                                .description("Gateway Server (Through Gateway)")
                 ))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
                 .components(new Components()
-                    .addSecuritySchemes("bearerAuth",
-                        new SecurityScheme()
-                            .type(SecurityScheme.Type.HTTP)
-                            .scheme("bearer")
-                            .bearerFormat("JWT")
-                            .description("JWT token for authentication")));
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME, new SecurityScheme()
+                                .name(SECURITY_SCHEME_NAME)
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .description("Enter JWT token with Bearer prefix, e.g. 'Bearer eyJhbGciOiJIUzI1NiJ9...'")));
     }
 }

--- a/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/config/WebConfig.java
+++ b/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/config/WebConfig.java
@@ -1,12 +1,6 @@
-package com.mankind.matrix_product_service.config;
+package com.mankind.matrix_wishlistservice.config;
 
-import feign.RequestInterceptor;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
-import org.springframework.util.StringUtils;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -30,18 +24,4 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowCredentials(true)
                 .maxAge(3600);
     }
-
-    @Bean
-    public RequestInterceptor propagateBearerToken() {
-        return template -> {
-            ServletRequestAttributes attrs =
-                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-            if (attrs != null) {
-                String auth = attrs.getRequest().getHeader(HttpHeaders.AUTHORIZATION);
-                if (StringUtils.hasText(auth)) {
-                    template.header(HttpHeaders.AUTHORIZATION, auth);
-                }
-            }
-        };
-    }
-}
+} 

--- a/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/controller/WishlistController.java
+++ b/wishlist-service/src/main/java/com/mankind/matrix_wishlistservice/controller/WishlistController.java
@@ -20,7 +20,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 @RestController
-@RequestMapping("/api/wishlist")
+@RequestMapping("/wishlist")
 @Tag(name = "Wishlist Management", description = "API endpoints for managing user wishlists")
 @SecurityRequirement(name = "bearerAuth")
 public class WishlistController {

--- a/wishlist-service/src/main/resources/application.yml
+++ b/wishlist-service/src/main/resources/application.yml
@@ -39,16 +39,15 @@ springdoc:
     path: /v3/api-docs
     enabled: true
   swagger-ui:
-    path: /swagger-ui.html
+    path: /swagger-ui
     operationsSorter: method
     tagsSorter: alpha
     tryItOutEnabled: true
-    disable-swagger-default-url: true
-  packages-to-scan: com.mankind.matrix_wishlistservice.controller
-  paths-to-match: /api/**
   show-actuator: false
   default-produces-media-type: application/json
   default-consumes-media-type: application/json
+  packages-to-scan: com.mankind.matrix_wishlistservice.controller
+  paths-to-match: /**
 
 management:
   endpoints:


### PR DESCRIPTION
## Overview

This PR resolves issues introduced with the gateway integration and includes several improvements for routing, documentation, and local development. It ensures compatibility with the updated Spring Boot version and standardizes how endpoints and Swagger docs are accessed.

---

## Changes Made

### Swagger Configuration

- Centralized all Swagger settings in the **parent `pom.xml`**
- Updated Swagger version to ensure compatibility with the updated Spring Boot version

### API Gateway Integration

- Made all endpoints accessible via the **API Gateway**
- Removed `/api/v1` from individual service paths
  - Example: `localhost:8080/category/1` instead of `localhost:8080/api/v1/category/1`
  - The gateway still uses `/api/v1` (e.g., `localhost:8085/api/v1/products/category/1`)

### Gateway Landing Page

- Created a simple homepage at `localhost:8085`
  - Lists all API endpoints
  - Provides links to Swagger documentation for each service

### Developer Tooling

- Added a script to run all services and the gateway at once locally
- Updated `docker-compose.yml` to include the gateway service
- Moved shared configuration settings from individual `pom.xml` files to the parent `pom.xml`

